### PR TITLE
feat(auth): add OIDC bearer authorization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -726,6 +726,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1192,8 +1209,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1203,8 +1222,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
+ "rand_core 0.10.1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1423,6 +1445,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -1625,6 +1648,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1704,6 +1742,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1770,12 +1814,16 @@ dependencies = [
  "aws-config",
  "aws-sdk-s3",
  "axum",
+ "base64",
  "blake3",
  "clap",
  "futures-util",
  "hex",
  "http 1.5.0",
  "http-body-util",
+ "jsonwebtoken",
+ "reqwest",
+ "rsa",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -1800,6 +1848,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint-dig"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1810,7 +1868,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand",
+ "rand 0.8.7",
  "smallvec",
  "zeroize",
 ]
@@ -1901,6 +1959,16 @@ dependencies = [
  "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
 ]
 
 [[package]]
@@ -1997,6 +2065,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+dependencies = [
+ "bytes",
+ "getrandom 0.4.3",
+ "lru-slab",
+ "rand 0.10.2",
+ "rand_pcg",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2019,7 +2143,18 @@ checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2029,7 +2164,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2039,6 +2174,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2083,6 +2233,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http 1.5.0",
+ "http-body 1.1.0",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots 1.0.9",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2109,12 +2297,18 @@ dependencies = [
  "num-traits",
  "pkcs1",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "signature",
  "spki",
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"
@@ -2171,6 +2365,7 @@ version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -2384,7 +2579,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror",
+ "time",
 ]
 
 [[package]]
@@ -2555,7 +2762,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rand",
+ "rand 0.8.7",
  "rsa",
  "serde",
  "sha1 0.10.7",
@@ -2594,7 +2801,7 @@ dependencies = [
  "md-5 0.10.6",
  "memchr",
  "once_cell",
- "rand",
+ "rand 0.8.7",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -2687,6 +2894,9 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -2883,13 +3093,16 @@ checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "bitflags",
  "bytes",
+ "futures-util",
  "http 1.5.0",
  "http-body 1.1.0",
  "http-body-util",
  "pin-project-lite",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
+ "url",
 ]
 
 [[package]]
@@ -3123,6 +3336,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3152,6 +3375,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,14 @@ async-trait = "0.1"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "default-https-client", "rt-tokio"] }
 aws-sdk-s3 = { version = "1", default-features = false, features = ["behavior-version-latest", "default-https-client", "rt-tokio"] }
 axum = { version = "0.8", features = ["http2", "json", "macros"] }
+base64 = "0.22"
 blake3 = "1"
 clap = { version = "4", features = ["derive", "env"] }
 futures-util = "0.3"
 hex = "0.4"
 http = "1"
+jsonwebtoken = "9"
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"
@@ -31,6 +34,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 
 [dev-dependencies]
 http-body-util = "0.1"
+rsa = { version = "0.9", features = ["pem"] }
 tower = { version = "0.5", features = ["util"] }
 
 [profile.release]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 - Filesystem storage for a single-node installation
 - S3-compatible storage for production, including MinIO
 - In-memory metadata for development or PostgreSQL for durable, horizontally scalable deployments
-- Bearer-token authorization with per-namespace read/write grants
+- Static and OIDC bearer authorization with per-namespace read/write grants
 - Recursive output-tree validation before an action result becomes visible
 - Batch missing-blob queries and Prometheus metrics
 - Docker Compose and Helm deployments
@@ -50,6 +50,7 @@ Every option has a matching environment variable and CLI flag. Run `mise-cache -
 | `MISE_CACHE_S3_REGION` | `us-east-1` | S3 region |
 | `MISE_CACHE_S3_PATH_STYLE` | `false` | Enable for MinIO and similar services |
 | `MISE_CACHE_TOKENS_JSON` | — | Token grants, described below |
+| `MISE_CACHE_OIDC_PROVIDERS_JSON` | — | Trusted OIDC providers and claim grants, described below |
 | `MISE_CACHE_ALLOW_ANONYMOUS` | `false` | Allow access without configured grants |
 | `MISE_CACHE_MAX_BLOB_BYTES` | `5368709120` | Maximum upload size |
 
@@ -70,6 +71,72 @@ AWS credentials use the standard AWS SDK credential chain, including environment
 ```
 
 Rotate tokens by deploying the old and new grants together, moving clients to the new token, and then removing the old grant. Do not put the JSON directly in a Helm values file; inject it through a Kubernetes Secret.
+
+OIDC lets CI systems use short-lived identity tokens instead of stored cache secrets. Configure trusted issuers, acceptable audiences, and one or more claim-based grants with `MISE_CACHE_OIDC_PROVIDERS_JSON`:
+
+```json
+[
+  {
+    "issuer": "https://token.actions.githubusercontent.com",
+    "audiences": ["https://cache.example.com"],
+    "rules": [
+      {
+        "claims": {
+          "repository": "jdx/mise",
+          "repository_owner_id": "216188"
+        },
+        "read": ["jdx/mise"],
+        "write": ["jdx/mise"]
+      }
+    ]
+  }
+]
+```
+
+The server discovers the issuer's JWKS endpoint, verifies the signature, issuer, audience, expiry, not-before time, and subject, then applies the first matching authorization rule. Rules are alternatives; every claim within a rule must match exactly. A configured claim may be an array of accepted scalar values, and a token claim may itself be an array. Namespace grants use the same exact, `*`, and `prefix/*` forms as static tokens.
+
+Authorization is deny-by-default: every provider needs at least one audience and rule, and every rule must constrain at least one claim. Pin stable identity claims such as GitHub's numeric `repository_owner_id` alongside the repository name; add `ref`, `environment`, or other claims when only a narrower workflow identity should be able to write. Symmetric JWT algorithms are never accepted.
+
+Optional provider settings are:
+
+| Field | Default | Purpose |
+|---|---:|---|
+| `discovery_uri` | `<issuer>/.well-known/openid-configuration` | Override OIDC discovery |
+| `jwks_uri` | discovered | Use an explicit JWKS endpoint and skip discovery |
+| `algorithms` | supported asymmetric algorithms | Restrict accepted JWT signing algorithms |
+| `jwks_refresh_seconds` | `300` | Refresh interval; an unknown key ID also triggers an immediate refresh |
+| `clock_skew_seconds` | `60` | Leeway for expiry and not-before validation |
+
+The service fetches keys at startup, refreshes stale keys during token validation, and immediately refreshes the JWKS when a provider rotates to an unknown key ID. If a periodic refresh temporarily fails, an already-cached key remains usable; an unknown key never does. Use HTTPS for discovery and JWKS endpoints outside a trusted private network.
+
+### GitHub Actions OIDC
+
+Until mise can acquire the job identity token itself, a workflow can request it from GitHub and pass it through the existing cache-token environment variable:
+
+```yaml
+permissions:
+  contents: read
+  id-token: write
+
+steps:
+  - uses: actions/checkout@v4
+  - name: acquire cache identity
+    id: cache-identity
+    env:
+      OIDC_AUDIENCE: https://cache.example.com
+    run: |
+      response="$(curl --fail --silent --show-error \
+        -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+        "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=$OIDC_AUDIENCE")"
+      token="$(jq -r .value <<<"$response")"
+      echo "::add-mask::$token"
+      echo "token=$token" >> "$GITHUB_OUTPUT"
+  - run: mise run test
+    env:
+      MISE_TASK_CACHE_REMOTE_TOKEN: ${{ steps.cache-identity.outputs.token }}
+```
+
+Treat the output as a secret even though it is short-lived. Set the audience in the workflow to exactly one of the provider's configured audiences.
 
 ## API
 
@@ -103,4 +170,3 @@ The protocol specification and mise client live in [jdx/mise](https://github.com
 ## License
 
 MIT
-

--- a/README.md
+++ b/README.md
@@ -104,10 +104,10 @@ Optional provider settings are:
 | `discovery_uri` | `<issuer>/.well-known/openid-configuration` | Override OIDC discovery |
 | `jwks_uri` | discovered | Use an explicit JWKS endpoint and skip discovery |
 | `algorithms` | supported asymmetric algorithms | Restrict accepted JWT signing algorithms |
-| `jwks_refresh_seconds` | `300` | Refresh interval; an unknown key ID also triggers an immediate refresh |
+| `jwks_refresh_seconds` | `300` | Refresh interval; an unknown key ID also requests a refresh |
 | `clock_skew_seconds` | `60` | Leeway for expiry and not-before validation |
 
-The service fetches keys at startup, refreshes stale keys during token validation, and immediately refreshes the JWKS when a provider rotates to an unknown key ID. If a periodic refresh temporarily fails, an already-cached key remains usable; an unknown key never does. Use HTTPS for discovery and JWKS endpoints outside a trusted private network.
+The service makes three bounded attempts to fetch provider metadata and keys at startup. It refreshes stale keys during token validation, and an unknown key ID requests a JWKS refresh. Refresh attempts have a 30-second cooldown to prevent attacker-controlled key IDs from amplifying outbound requests. If a periodic refresh temporarily fails, an already-cached key remains usable; an unknown key never does. Use HTTPS for discovery and JWKS endpoints outside a trusted private network.
 
 ### GitHub Actions OIDC
 

--- a/charts/mise-cache/templates/deployment.yaml
+++ b/charts/mise-cache/templates/deployment.yaml
@@ -29,10 +29,11 @@ spec:
             - {name: MISE_CACHE_S3_PATH_STYLE, value: {{ .Values.config.s3PathStyle | quote }}}
             - {name: MISE_CACHE_MAX_BLOB_BYTES, value: {{ .Values.config.maxBlobBytes | quote }}}
             - name: MISE_CACHE_TOKENS_JSON
-              valueFrom: {secretKeyRef: {name: {{ .Values.secret.existingSecret }}, key: {{ .Values.secret.tokensKey }}}}
+              valueFrom: {secretKeyRef: {name: {{ .Values.secret.existingSecret }}, key: {{ .Values.secret.tokensKey }}, optional: true}}
+            - name: MISE_CACHE_OIDC_PROVIDERS_JSON
+              valueFrom: {secretKeyRef: {name: {{ .Values.secret.existingSecret }}, key: {{ .Values.secret.oidcProvidersKey }}, optional: true}}
           readinessProbe: {httpGet: {path: /v1/status, port: http}, initialDelaySeconds: 2}
           livenessProbe: {httpGet: {path: /v1/status, port: http}, initialDelaySeconds: 5}
           resources: {{ toYaml .Values.resources | nindent 12 }}
           volumeMounts: [{name: tmp, mountPath: /tmp}]
       volumes: [{name: tmp, emptyDir: {}}]
-

--- a/charts/mise-cache/values.yaml
+++ b/charts/mise-cache/values.yaml
@@ -20,6 +20,7 @@ config:
 secret:
   existingSecret: mise-cache
   tokensKey: tokens-json
+  oidcProvidersKey: oidc-providers-json
 serviceAccount:
   create: true
   name: ""

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,7 +1,36 @@
+use std::{
+    collections::BTreeMap,
+    str::FromStr,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use anyhow::{Context, anyhow, bail};
 use axum::http::HeaderMap;
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+use jsonwebtoken::{
+    Algorithm, DecodingKey, Validation, decode, decode_header,
+    jwk::{JwkSet, KeyOperations, PublicKeyUse},
+};
 use serde::Deserialize;
+use serde_json::Value;
+use tokio::sync::{Mutex, RwLock};
 
 use crate::server::ApiError;
+
+const DEFAULT_JWKS_REFRESH_SECONDS: u64 = 300;
+const DEFAULT_CLOCK_SKEW_SECONDS: u64 = 60;
+const DEFAULT_ALGORITHMS: &[Algorithm] = &[
+    Algorithm::RS256,
+    Algorithm::RS384,
+    Algorithm::RS512,
+    Algorithm::PS256,
+    Algorithm::PS384,
+    Algorithm::PS512,
+    Algorithm::ES256,
+    Algorithm::ES384,
+    Algorithm::EdDSA,
+];
 
 #[derive(Clone, Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -13,9 +42,76 @@ pub struct TokenGrant {
     pub write: Vec<String>,
 }
 
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct OidcProviderConfig {
+    issuer: String,
+    audiences: Vec<String>,
+    #[serde(default)]
+    discovery_uri: Option<String>,
+    #[serde(default)]
+    jwks_uri: Option<String>,
+    #[serde(default)]
+    algorithms: Vec<String>,
+    #[serde(default = "default_jwks_refresh_seconds")]
+    jwks_refresh_seconds: u64,
+    #[serde(default = "default_clock_skew_seconds")]
+    clock_skew_seconds: u64,
+    rules: Vec<OidcRule>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct OidcRule {
+    claims: BTreeMap<String, ClaimRequirement>,
+    #[serde(default)]
+    read: Vec<String>,
+    #[serde(default)]
+    write: Vec<String>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(untagged)]
+enum ClaimRequirement {
+    One(ScalarValue),
+    Any(Vec<ScalarValue>),
+}
+
+#[derive(Clone, Debug, PartialEq, Deserialize)]
+#[serde(untagged)]
+enum ScalarValue {
+    String(String),
+    Number(serde_json::Number),
+    Bool(bool),
+}
+
+#[derive(Debug, Deserialize)]
+struct DiscoveryDocument {
+    issuer: String,
+    jwks_uri: String,
+    #[serde(default)]
+    id_token_signing_alg_values_supported: Vec<String>,
+}
+
+#[derive(Clone)]
+struct OidcProvider {
+    config: Arc<OidcProviderConfig>,
+    algorithms: Arc<Vec<Algorithm>>,
+    jwks_uri: Arc<str>,
+    client: reqwest::Client,
+    keys: Arc<RwLock<CachedKeys>>,
+    refresh: Arc<Mutex<()>>,
+}
+
+struct CachedKeys {
+    set: JwkSet,
+    fetched_at: Instant,
+}
+
 #[derive(Clone)]
 pub struct Authorizer {
     grants: Vec<TokenGrant>,
+    oidc: Vec<OidcProvider>,
     allow_anonymous: bool,
 }
 
@@ -26,18 +122,33 @@ pub enum Access {
 }
 
 impl Authorizer {
-    pub fn new(json: Option<&str>, allow_anonymous: bool) -> anyhow::Result<Self> {
-        let grants = match json {
-            Some(json) => serde_json::from_str(json)?,
-            None => Vec::new(),
-        };
+    pub async fn new(
+        tokens_json: Option<&str>,
+        oidc_providers_json: Option<&str>,
+        allow_anonymous: bool,
+    ) -> anyhow::Result<Self> {
+        let grants: Vec<TokenGrant> = parse_json_array(tokens_json, "token grants")?;
+        let configs: Vec<OidcProviderConfig> =
+            parse_json_array(oidc_providers_json, "OIDC providers")?;
+        let mut issuers = std::collections::BTreeSet::new();
+        let mut oidc = Vec::with_capacity(configs.len());
+        for config in configs {
+            if !issuers.insert(config.issuer.clone()) {
+                bail!(
+                    "OIDC issuer {:?} is configured more than once",
+                    config.issuer
+                );
+            }
+            oidc.push(OidcProvider::new(config).await?);
+        }
         Ok(Self {
             grants,
+            oidc,
             allow_anonymous,
         })
     }
 
-    pub fn authorize(&self, headers: &HeaderMap, access: Access) -> Result<String, ApiError> {
+    pub async fn authorize(&self, headers: &HeaderMap, access: Access) -> Result<String, ApiError> {
         if headers
             .get("mise-cache-protocol")
             .and_then(|value| value.to_str().ok())
@@ -53,7 +164,7 @@ impl Authorizer {
                 ApiError::bad_request("a valid Mise-Cache-Namespace header is required")
             })?;
 
-        if self.allow_anonymous && self.grants.is_empty() {
+        if self.allow_anonymous && self.grants.is_empty() && self.oidc.is_empty() {
             return Ok(namespace.to_owned());
         }
         let token = headers
@@ -61,26 +172,319 @@ impl Authorizer {
             .and_then(|value| value.to_str().ok())
             .and_then(|value| value.strip_prefix("Bearer "))
             .ok_or_else(|| ApiError::unauthorized("a bearer token is required"))?;
-        let grant = self
+
+        if let Some(grant) = self
             .grants
             .iter()
             .find(|grant| constant_time_eq(grant.token.as_bytes(), token.as_bytes()))
-            .ok_or_else(|| ApiError::unauthorized("invalid bearer token"))?;
-        let patterns = match access {
-            Access::Read => &grant.read,
-            Access::Write => &grant.write,
-        };
-        if patterns
-            .iter()
-            .any(|pattern| matches_namespace(pattern, namespace))
         {
+            return authorize_patterns(patterns(grant, access), namespace);
+        }
+
+        let issuer =
+            unverified_issuer(token).map_err(|_| ApiError::unauthorized("invalid bearer token"))?;
+        let provider = self
+            .oidc
+            .iter()
+            .find(|provider| provider.config.issuer == issuer)
+            .ok_or_else(|| ApiError::unauthorized("invalid bearer token"))?;
+        let claims = provider.verify(token).await.map_err(|error| {
+            tracing::warn!(%error, issuer, "OIDC token validation failed");
+            ApiError::unauthorized("invalid bearer token")
+        })?;
+        let authorized = provider.config.rules.iter().any(|rule| {
+            rule.matches_claims(&claims)
+                && rule
+                    .patterns(access)
+                    .iter()
+                    .any(|pattern| matches_namespace(pattern, namespace))
+        });
+        if authorized {
             Ok(namespace.to_owned())
         } else {
             Err(ApiError::forbidden(
-                "token is not authorized for this namespace",
+                "identity is not authorized for this namespace",
             ))
         }
     }
+}
+
+impl OidcProvider {
+    async fn new(config: OidcProviderConfig) -> anyhow::Result<Self> {
+        validate_provider_config(&config)?;
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(10))
+            .build()?;
+        let (jwks_uri, advertised_algorithms) = if let Some(uri) = &config.jwks_uri {
+            (uri.clone(), Vec::new())
+        } else {
+            let discovery_uri = config.discovery_uri.clone().unwrap_or_else(|| {
+                format!(
+                    "{}/.well-known/openid-configuration",
+                    config.issuer.trim_end_matches('/')
+                )
+            });
+            let document: DiscoveryDocument = fetch_json(&client, &discovery_uri)
+                .await
+                .with_context(|| format!("discover OIDC issuer {}", config.issuer))?;
+            if document.issuer != config.issuer {
+                bail!(
+                    "OIDC discovery issuer mismatch: configured {:?}, received {:?}",
+                    config.issuer,
+                    document.issuer
+                );
+            }
+            (
+                document.jwks_uri,
+                document.id_token_signing_alg_values_supported,
+            )
+        };
+        let algorithms = configured_algorithms(&config.algorithms, &advertised_algorithms)?;
+        let set = fetch_jwks(&client, &jwks_uri)
+            .await
+            .with_context(|| format!("fetch OIDC keys for {}", config.issuer))?;
+        Ok(Self {
+            config: Arc::new(config),
+            algorithms: Arc::new(algorithms),
+            jwks_uri: jwks_uri.into(),
+            client,
+            keys: Arc::new(RwLock::new(CachedKeys {
+                set,
+                fetched_at: Instant::now(),
+            })),
+            refresh: Arc::new(Mutex::new(())),
+        })
+    }
+
+    async fn verify(&self, token: &str) -> anyhow::Result<Value> {
+        let header = decode_header(token).context("decode JWT header")?;
+        let kid = header.kid.as_deref().context("JWT header is missing kid")?;
+        if !self.algorithms.contains(&header.alg) {
+            bail!("JWT uses a disallowed signing algorithm");
+        }
+
+        let keys = self.keys.read().await;
+        let stale =
+            keys.fetched_at.elapsed() >= Duration::from_secs(self.config.jwks_refresh_seconds);
+        let known_key = keys.set.find(kid).is_some();
+        drop(keys);
+        if (stale || !known_key)
+            && let Err(error) = self.refresh_keys(kid).await
+        {
+            if !known_key {
+                return Err(error);
+            }
+            tracing::warn!(%error, issuer = self.config.issuer, "using stale OIDC keys after refresh failed");
+        }
+        let key = {
+            let keys = self.keys.read().await;
+            let jwk = keys
+                .set
+                .find(kid)
+                .context("JWT signing key was not found")?;
+            if jwk
+                .common
+                .key_algorithm
+                .is_some_and(|algorithm| algorithm.to_string() != format!("{:?}", header.alg))
+                || jwk
+                    .common
+                    .public_key_use
+                    .as_ref()
+                    .is_some_and(|usage| usage != &PublicKeyUse::Signature)
+                || jwk
+                    .common
+                    .key_operations
+                    .as_ref()
+                    .is_some_and(|operations| !operations.contains(&KeyOperations::Verify))
+            {
+                bail!("JWT signing key is not valid for this algorithm");
+            }
+            DecodingKey::from_jwk(jwk).context("decode JWT signing key")?
+        };
+
+        let mut validation = Validation::new(header.alg);
+        validation.set_audience(&self.config.audiences);
+        validation.set_issuer(&[&self.config.issuer]);
+        validation.set_required_spec_claims(&["exp", "aud", "iss", "sub"]);
+        validation.validate_nbf = true;
+        validation.leeway = self.config.clock_skew_seconds;
+        Ok(decode::<Value>(token, &key, &validation)
+            .context("validate JWT")?
+            .claims)
+    }
+
+    async fn refresh_keys(&self, kid: &str) -> anyhow::Result<()> {
+        let _guard = self.refresh.lock().await;
+        {
+            let keys = self.keys.read().await;
+            if keys.fetched_at.elapsed() < Duration::from_secs(self.config.jwks_refresh_seconds)
+                && keys.set.find(kid).is_some()
+            {
+                return Ok(());
+            }
+        }
+        let set = fetch_jwks(&self.client, &self.jwks_uri).await?;
+        let mut keys = self.keys.write().await;
+        keys.set = set;
+        keys.fetched_at = Instant::now();
+        Ok(())
+    }
+}
+
+impl OidcRule {
+    fn patterns(&self, access: Access) -> &[String] {
+        match access {
+            Access::Read => &self.read,
+            Access::Write => &self.write,
+        }
+    }
+
+    fn matches_claims(&self, claims: &Value) -> bool {
+        self.claims.iter().all(|(name, requirement)| {
+            claims
+                .get(name)
+                .is_some_and(|actual| requirement.matches(actual))
+        })
+    }
+}
+
+impl ClaimRequirement {
+    fn matches(&self, actual: &Value) -> bool {
+        let expected = match self {
+            Self::One(value) => std::slice::from_ref(value),
+            Self::Any(values) => values,
+        };
+        match actual {
+            Value::Array(values) => values
+                .iter()
+                .any(|actual| expected.iter().any(|value| value.matches(actual))),
+            actual => expected.iter().any(|value| value.matches(actual)),
+        }
+    }
+}
+
+impl ScalarValue {
+    fn matches(&self, actual: &Value) -> bool {
+        match (self, actual) {
+            (Self::String(expected), Value::String(actual)) => expected == actual,
+            (Self::Number(expected), Value::Number(actual)) => expected == actual,
+            (Self::Bool(expected), Value::Bool(actual)) => expected == actual,
+            _ => false,
+        }
+    }
+}
+
+fn parse_json_array<T: for<'de> Deserialize<'de>>(
+    json: Option<&str>,
+    label: &str,
+) -> anyhow::Result<Vec<T>> {
+    json.map(serde_json::from_str)
+        .transpose()
+        .with_context(|| format!("parse {label} JSON"))
+        .map(Option::unwrap_or_default)
+}
+
+fn validate_provider_config(config: &OidcProviderConfig) -> anyhow::Result<()> {
+    if config.issuer.is_empty() || config.audiences.is_empty() || config.rules.is_empty() {
+        bail!("each OIDC provider requires issuer, audiences, and rules");
+    }
+    if config.jwks_refresh_seconds == 0 {
+        bail!("OIDC jwks_refresh_seconds must be greater than zero");
+    }
+    if config.rules.iter().any(|rule| rule.claims.is_empty()) {
+        bail!("each OIDC authorization rule must require at least one claim");
+    }
+    Ok(())
+}
+
+fn configured_algorithms(
+    configured: &[String],
+    advertised: &[String],
+) -> anyhow::Result<Vec<Algorithm>> {
+    let mut algorithms = if configured.is_empty() {
+        DEFAULT_ALGORITHMS.to_vec()
+    } else {
+        configured
+            .iter()
+            .map(|name| {
+                Algorithm::from_str(name)
+                    .map_err(|_| anyhow!("unsupported OIDC algorithm {name:?}"))
+            })
+            .collect::<anyhow::Result<Vec<_>>>()?
+    };
+    algorithms.retain(|algorithm| DEFAULT_ALGORITHMS.contains(algorithm));
+    if !advertised.is_empty() {
+        algorithms.retain(|algorithm| {
+            advertised
+                .iter()
+                .any(|name| name == &format!("{algorithm:?}"))
+        });
+    }
+    if algorithms.is_empty() {
+        bail!("OIDC provider has no mutually supported asymmetric signing algorithm");
+    }
+    Ok(algorithms)
+}
+
+async fn fetch_jwks(client: &reqwest::Client, uri: &str) -> anyhow::Result<JwkSet> {
+    fetch_json(client, uri).await.context("fetch JWKS")
+}
+
+async fn fetch_json<T: for<'de> Deserialize<'de>>(
+    client: &reqwest::Client,
+    uri: &str,
+) -> anyhow::Result<T> {
+    Ok(client
+        .get(uri)
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?)
+}
+
+fn unverified_issuer(token: &str) -> anyhow::Result<String> {
+    let mut parts = token.split('.');
+    let _header = parts.next().context("JWT is missing header")?;
+    let payload = parts.next().context("JWT is missing payload")?;
+    let _signature = parts.next().context("JWT is missing signature")?;
+    if parts.next().is_some() {
+        bail!("JWT has too many segments");
+    }
+    let claims: Value = serde_json::from_slice(&URL_SAFE_NO_PAD.decode(payload)?)?;
+    claims
+        .get("iss")
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned)
+        .context("JWT is missing issuer")
+}
+
+fn patterns(grant: &TokenGrant, access: Access) -> &[String] {
+    match access {
+        Access::Read => &grant.read,
+        Access::Write => &grant.write,
+    }
+}
+
+fn authorize_patterns(patterns: &[String], namespace: &str) -> Result<String, ApiError> {
+    if patterns
+        .iter()
+        .any(|pattern| matches_namespace(pattern, namespace))
+    {
+        Ok(namespace.to_owned())
+    } else {
+        Err(ApiError::forbidden(
+            "token is not authorized for this namespace",
+        ))
+    }
+}
+
+const fn default_jwks_refresh_seconds() -> u64 {
+    DEFAULT_JWKS_REFRESH_SECONDS
+}
+
+const fn default_clock_skew_seconds() -> u64 {
+    DEFAULT_CLOCK_SKEW_SECONDS
 }
 
 fn valid_namespace(value: &str) -> bool {
@@ -115,6 +519,16 @@ fn constant_time_eq(left: &[u8], right: &[u8]) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use axum::{Json, Router, extract::State, routing::get};
+    use jsonwebtoken::{EncodingKey, Header, encode};
+    use rsa::{
+        RsaPrivateKey, RsaPublicKey,
+        pkcs8::{EncodePrivateKey, LineEnding},
+        rand_core::OsRng,
+        traits::PublicKeyParts,
+    };
+    use std::time::{SystemTime, UNIX_EPOCH};
+    use tokio::net::TcpListener;
 
     #[test]
     fn namespace_patterns_do_not_overmatch() {
@@ -129,5 +543,154 @@ mod tests {
         assert!(valid_namespace("acme/project-a"));
         assert!(!valid_namespace("../project"));
         assert!(!valid_namespace("project name"));
+    }
+
+    #[test]
+    fn claim_requirements_match_scalars_and_arrays() {
+        let claims = serde_json::json!({"repository":"jdx/mise", "groups":["dev", "release"]});
+        let rule: OidcRule = serde_json::from_value(serde_json::json!({
+            "claims":{"repository":"jdx/mise", "groups":["ops", "release"]},
+            "read":["jdx/mise"]
+        }))
+        .unwrap();
+        assert!(rule.matches_claims(&claims));
+    }
+
+    #[test]
+    fn rejects_hmac_algorithms() {
+        assert!(configured_algorithms(&["HS256".into()], &[]).is_err());
+    }
+
+    #[tokio::test]
+    async fn validates_oidc_signature_audience_claims_and_permissions() {
+        let private = RsaPrivateKey::new(&mut OsRng, 2048).unwrap();
+        let public = RsaPublicKey::from(&private);
+        let jwks = Arc::new(RwLock::new(serde_json::json!({"keys":[{
+            "kty":"RSA",
+            "use":"sig",
+            "alg":"RS256",
+            "kid":"test-key",
+            "n":URL_SAFE_NO_PAD.encode(public.n().to_bytes_be()),
+            "e":URL_SAFE_NO_PAD.encode(public.e().to_bytes_be())
+        }]})));
+        let app = Router::new()
+            .route(
+                "/jwks",
+                get(|State(jwks): State<Arc<RwLock<Value>>>| async move {
+                    Json(jwks.read().await.clone())
+                }),
+            )
+            .with_state(jwks.clone());
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+        let issuer = "https://issuer.example";
+        let providers = serde_json::json!([{
+            "issuer":issuer,
+            "audiences":["https://cache.example"],
+            "jwks_uri":format!("http://{address}/jwks"),
+            "rules":[{
+                "claims":{"repository":"jdx/mise", "repository_owner_id":"216188"},
+                "read":["jdx/mise"],
+                "write":["jdx/mise"]
+            }]
+        }]);
+        let authorizer = Authorizer::new(None, Some(&providers.to_string()), false)
+            .await
+            .unwrap();
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let claims = serde_json::json!({
+            "iss":issuer,
+            "aud":"https://cache.example",
+            "sub":"repo:jdx/mise:ref:refs/heads/main",
+            "exp":now + 300,
+            "nbf":now - 1,
+            "repository":"jdx/mise",
+            "repository_owner_id":"216188"
+        });
+        let mut header = Header::new(Algorithm::RS256);
+        header.kid = Some("test-key".into());
+        let pem = private.to_pkcs8_pem(LineEnding::LF).unwrap();
+        let token = encode(
+            &header,
+            &claims,
+            &EncodingKey::from_rsa_pem(pem.as_bytes()).unwrap(),
+        )
+        .unwrap();
+        let verified = authorizer.oidc[0].verify(&token).await.unwrap();
+        assert!(authorizer.oidc[0].config.rules[0].matches_claims(&verified));
+        let headers = request_headers(&token, "jdx/mise");
+        assert!(authorizer.authorize(&headers, Access::Write).await.is_ok());
+
+        let denied_headers = request_headers(&token, "another/project");
+        assert!(
+            authorizer
+                .authorize(&denied_headers, Access::Read)
+                .await
+                .is_err()
+        );
+
+        let wrong_audience = serde_json::json!({
+            "iss":issuer,
+            "aud":"https://attacker.example",
+            "sub":"repo:jdx/mise:ref:refs/heads/main",
+            "exp":now + 300,
+            "repository":"jdx/mise",
+            "repository_owner_id":"216188"
+        });
+        let token = encode(
+            &header,
+            &wrong_audience,
+            &EncodingKey::from_rsa_pem(pem.as_bytes()).unwrap(),
+        )
+        .unwrap();
+        assert!(
+            authorizer
+                .authorize(&request_headers(&token, "jdx/mise"), Access::Read)
+                .await
+                .is_err()
+        );
+
+        let rotated_private = RsaPrivateKey::new(&mut OsRng, 2048).unwrap();
+        let rotated_public = RsaPublicKey::from(&rotated_private);
+        *jwks.write().await = serde_json::json!({"keys":[{
+            "kty":"RSA",
+            "use":"sig",
+            "alg":"RS256",
+            "kid":"rotated-key",
+            "n":URL_SAFE_NO_PAD.encode(rotated_public.n().to_bytes_be()),
+            "e":URL_SAFE_NO_PAD.encode(rotated_public.e().to_bytes_be())
+        }]});
+        let mut rotated_header = Header::new(Algorithm::RS256);
+        rotated_header.kid = Some("rotated-key".into());
+        let rotated_pem = rotated_private.to_pkcs8_pem(LineEnding::LF).unwrap();
+        let rotated_token = encode(
+            &rotated_header,
+            &claims,
+            &EncodingKey::from_rsa_pem(rotated_pem.as_bytes()).unwrap(),
+        )
+        .unwrap();
+        assert!(
+            authorizer
+                .authorize(&request_headers(&rotated_token, "jdx/mise"), Access::Write)
+                .await
+                .is_ok()
+        );
+        server.abort();
+    }
+
+    fn request_headers(token: &str, namespace: &str) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        headers.insert("mise-cache-protocol", "1".parse().unwrap());
+        headers.insert("mise-cache-namespace", namespace.parse().unwrap());
+        headers.insert(
+            axum::http::header::AUTHORIZATION,
+            format!("Bearer {token}").parse().unwrap(),
+        );
+        headers
     }
 }

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -20,6 +20,9 @@ use crate::server::ApiError;
 
 const DEFAULT_JWKS_REFRESH_SECONDS: u64 = 300;
 const DEFAULT_CLOCK_SKEW_SECONDS: u64 = 60;
+const MIN_JWKS_REFRESH_SECONDS: u64 = 30;
+const INITIAL_FETCH_ATTEMPTS: u32 = 3;
+const INITIAL_FETCH_BACKOFF_MILLIS: u64 = 250;
 const DEFAULT_ALGORITHMS: &[Algorithm] = &[
     Algorithm::RS256,
     Algorithm::RS384,
@@ -101,11 +104,13 @@ struct OidcProvider {
     client: reqwest::Client,
     keys: Arc<RwLock<CachedKeys>>,
     refresh: Arc<Mutex<()>>,
+    min_refresh_interval: Duration,
 }
 
 struct CachedKeys {
     set: JwkSet,
     fetched_at: Instant,
+    attempted_at: Instant,
 }
 
 #[derive(Clone)]
@@ -215,34 +220,10 @@ impl OidcProvider {
         let client = reqwest::Client::builder()
             .timeout(Duration::from_secs(10))
             .build()?;
-        let (jwks_uri, advertised_algorithms) = if let Some(uri) = &config.jwks_uri {
-            (uri.clone(), Vec::new())
-        } else {
-            let discovery_uri = config.discovery_uri.clone().unwrap_or_else(|| {
-                format!(
-                    "{}/.well-known/openid-configuration",
-                    config.issuer.trim_end_matches('/')
-                )
-            });
-            let document: DiscoveryDocument = fetch_json(&client, &discovery_uri)
-                .await
-                .with_context(|| format!("discover OIDC issuer {}", config.issuer))?;
-            if document.issuer != config.issuer {
-                bail!(
-                    "OIDC discovery issuer mismatch: configured {:?}, received {:?}",
-                    config.issuer,
-                    document.issuer
-                );
-            }
-            (
-                document.jwks_uri,
-                document.id_token_signing_alg_values_supported,
-            )
-        };
+        let (jwks_uri, advertised_algorithms, set) =
+            fetch_initial_provider_data(&client, &config).await?;
         let algorithms = configured_algorithms(&config.algorithms, &advertised_algorithms)?;
-        let set = fetch_jwks(&client, &jwks_uri)
-            .await
-            .with_context(|| format!("fetch OIDC keys for {}", config.issuer))?;
+        let now = Instant::now();
         Ok(Self {
             config: Arc::new(config),
             algorithms: Arc::new(algorithms),
@@ -250,9 +231,11 @@ impl OidcProvider {
             client,
             keys: Arc::new(RwLock::new(CachedKeys {
                 set,
-                fetched_at: Instant::now(),
+                fetched_at: now,
+                attempted_at: now,
             })),
             refresh: Arc::new(Mutex::new(())),
+            min_refresh_interval: Duration::from_secs(MIN_JWKS_REFRESH_SECONDS),
         })
     }
 
@@ -282,15 +265,13 @@ impl OidcProvider {
                 .set
                 .find(kid)
                 .context("JWT signing key was not found")?;
-            if jwk
+            if jwk.common.key_algorithm.is_some_and(|algorithm| {
+                Algorithm::from_str(&algorithm.to_string()).ok() != Some(header.alg)
+            }) || jwk
                 .common
-                .key_algorithm
-                .is_some_and(|algorithm| algorithm.to_string() != format!("{:?}", header.alg))
-                || jwk
-                    .common
-                    .public_key_use
-                    .as_ref()
-                    .is_some_and(|usage| usage != &PublicKeyUse::Signature)
+                .public_key_use
+                .as_ref()
+                .is_some_and(|usage| usage != &PublicKeyUse::Signature)
                 || jwk
                     .common
                     .key_operations
@@ -317,12 +298,15 @@ impl OidcProvider {
         let _guard = self.refresh.lock().await;
         {
             let keys = self.keys.read().await;
-            if keys.fetched_at.elapsed() < Duration::from_secs(self.config.jwks_refresh_seconds)
-                && keys.set.find(kid).is_some()
+            if keys.attempted_at.elapsed() < self.min_refresh_interval
+                || (keys.fetched_at.elapsed()
+                    < Duration::from_secs(self.config.jwks_refresh_seconds)
+                    && keys.set.find(kid).is_some())
             {
                 return Ok(());
             }
         }
+        self.keys.write().await.attempted_at = Instant::now();
         let set = fetch_jwks(&self.client, &self.jwks_uri).await?;
         let mut keys = self.keys.write().await;
         keys.set = set;
@@ -414,16 +398,80 @@ fn configured_algorithms(
     };
     algorithms.retain(|algorithm| DEFAULT_ALGORITHMS.contains(algorithm));
     if !advertised.is_empty() {
-        algorithms.retain(|algorithm| {
-            advertised
-                .iter()
-                .any(|name| name == &format!("{algorithm:?}"))
-        });
+        let advertised = advertised
+            .iter()
+            .filter_map(|name| Algorithm::from_str(name).ok())
+            .collect::<Vec<_>>();
+        algorithms.retain(|algorithm| advertised.contains(algorithm));
     }
     if algorithms.is_empty() {
         bail!("OIDC provider has no mutually supported asymmetric signing algorithm");
     }
     Ok(algorithms)
+}
+
+async fn fetch_initial_provider_data(
+    client: &reqwest::Client,
+    config: &OidcProviderConfig,
+) -> anyhow::Result<(String, Vec<String>, JwkSet)> {
+    let mut last_error = None;
+    for attempt in 1..=INITIAL_FETCH_ATTEMPTS {
+        match fetch_provider_data(client, config).await {
+            Ok(data) => return Ok(data),
+            Err(error) => {
+                tracing::warn!(
+                    %error,
+                    issuer = config.issuer,
+                    attempt,
+                    max_attempts = INITIAL_FETCH_ATTEMPTS,
+                    "initial OIDC provider fetch failed"
+                );
+                last_error = Some(error);
+                if attempt < INITIAL_FETCH_ATTEMPTS {
+                    tokio::time::sleep(Duration::from_millis(
+                        INITIAL_FETCH_BACKOFF_MILLIS * u64::from(attempt),
+                    ))
+                    .await;
+                }
+            }
+        }
+    }
+    Err(last_error.expect("at least one OIDC fetch attempt"))
+        .with_context(|| format!("initialize OIDC issuer {}", config.issuer))
+}
+
+async fn fetch_provider_data(
+    client: &reqwest::Client,
+    config: &OidcProviderConfig,
+) -> anyhow::Result<(String, Vec<String>, JwkSet)> {
+    let (jwks_uri, advertised_algorithms) = if let Some(uri) = &config.jwks_uri {
+        (uri.clone(), Vec::new())
+    } else {
+        let discovery_uri = config.discovery_uri.clone().unwrap_or_else(|| {
+            format!(
+                "{}/.well-known/openid-configuration",
+                config.issuer.trim_end_matches('/')
+            )
+        });
+        let document: DiscoveryDocument = fetch_json(client, &discovery_uri)
+            .await
+            .with_context(|| format!("discover OIDC issuer {}", config.issuer))?;
+        if document.issuer != config.issuer {
+            bail!(
+                "OIDC discovery issuer mismatch: configured {:?}, received {:?}",
+                config.issuer,
+                document.issuer
+            );
+        }
+        (
+            document.jwks_uri,
+            document.id_token_signing_alg_values_supported,
+        )
+    };
+    let set = fetch_jwks(client, &jwks_uri)
+        .await
+        .with_context(|| format!("fetch OIDC keys for {}", config.issuer))?;
+    Ok((jwks_uri, advertised_algorithms, set))
 }
 
 async fn fetch_jwks(client: &reqwest::Client, uri: &str) -> anyhow::Result<JwkSet> {
@@ -519,7 +567,9 @@ fn constant_time_eq(left: &[u8], right: &[u8]) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use axum::{Json, Router, extract::State, routing::get};
+    use axum::{
+        Json, Router, extract::State, http::StatusCode, response::IntoResponse, routing::get,
+    };
     use jsonwebtoken::{EncodingKey, Header, encode};
     use rsa::{
         RsaPrivateKey, RsaPublicKey,
@@ -527,7 +577,10 @@ mod tests {
         rand_core::OsRng,
         traits::PublicKeyParts,
     };
-    use std::time::{SystemTime, UNIX_EPOCH};
+    use std::{
+        sync::atomic::{AtomicUsize, Ordering},
+        time::{SystemTime, UNIX_EPOCH},
+    };
     use tokio::net::TcpListener;
 
     #[test]
@@ -559,6 +612,38 @@ mod tests {
     #[test]
     fn rejects_hmac_algorithms() {
         assert!(configured_algorithms(&["HS256".into()], &[]).is_err());
+    }
+
+    #[tokio::test]
+    async fn retries_initial_jwks_fetches() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let app = Router::new()
+            .route(
+                "/jwks",
+                get(|State(attempts): State<Arc<AtomicUsize>>| async move {
+                    if attempts.fetch_add(1, Ordering::SeqCst) < 2 {
+                        StatusCode::SERVICE_UNAVAILABLE.into_response()
+                    } else {
+                        Json(serde_json::json!({"keys":[]})).into_response()
+                    }
+                }),
+            )
+            .with_state(attempts.clone());
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        let providers = serde_json::json!([{
+            "issuer":"https://issuer.example",
+            "audiences":["https://cache.example"],
+            "jwks_uri":format!("http://{address}/jwks"),
+            "rules":[{"claims":{"repository":"jdx/mise"}, "read":["jdx/mise"]}]
+        }]);
+
+        Authorizer::new(None, Some(&providers.to_string()), false)
+            .await
+            .unwrap();
+        assert_eq!(attempts.load(Ordering::SeqCst), 3);
+        server.abort();
     }
 
     #[tokio::test]
@@ -596,7 +681,7 @@ mod tests {
                 "write":["jdx/mise"]
             }]
         }]);
-        let authorizer = Authorizer::new(None, Some(&providers.to_string()), false)
+        let mut authorizer = Authorizer::new(None, Some(&providers.to_string()), false)
             .await
             .unwrap();
         let now = SystemTime::now()
@@ -674,6 +759,13 @@ mod tests {
             &EncodingKey::from_rsa_pem(rotated_pem.as_bytes()).unwrap(),
         )
         .unwrap();
+        assert!(
+            authorizer
+                .authorize(&request_headers(&rotated_token, "jdx/mise"), Access::Write)
+                .await
+                .is_err()
+        );
+        authorizer.oidc[0].min_refresh_interval = Duration::ZERO;
         assert!(
             authorizer
                 .authorize(&request_headers(&rotated_token, "jdx/mise"), Access::Write)

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -110,7 +110,7 @@ struct OidcProvider {
 struct CachedKeys {
     set: JwkSet,
     fetched_at: Instant,
-    attempted_at: Instant,
+    attempted_at: Option<Instant>,
 }
 
 #[derive(Clone)]
@@ -232,7 +232,7 @@ impl OidcProvider {
             keys: Arc::new(RwLock::new(CachedKeys {
                 set,
                 fetched_at: now,
-                attempted_at: now,
+                attempted_at: None,
             })),
             refresh: Arc::new(Mutex::new(())),
             min_refresh_interval: Duration::from_secs(MIN_JWKS_REFRESH_SECONDS),
@@ -298,7 +298,9 @@ impl OidcProvider {
         let _guard = self.refresh.lock().await;
         {
             let keys = self.keys.read().await;
-            if keys.attempted_at.elapsed() < self.min_refresh_interval
+            if keys
+                .attempted_at
+                .is_some_and(|attempted_at| attempted_at.elapsed() < self.min_refresh_interval)
                 || (keys.fetched_at.elapsed()
                     < Duration::from_secs(self.config.jwks_refresh_seconds)
                     && keys.set.find(kid).is_some())
@@ -306,7 +308,7 @@ impl OidcProvider {
                 return Ok(());
             }
         }
-        self.keys.write().await.attempted_at = Instant::now();
+        self.keys.write().await.attempted_at = Some(Instant::now());
         let set = fetch_jwks(&self.client, &self.jwks_uri).await?;
         let mut keys = self.keys.write().await;
         keys.set = set;
@@ -763,12 +765,35 @@ mod tests {
             authorizer
                 .authorize(&request_headers(&rotated_token, "jdx/mise"), Access::Write)
                 .await
+                .is_ok()
+        );
+
+        *jwks.write().await = serde_json::json!({"keys":[{
+            "kty":"RSA",
+            "use":"sig",
+            "alg":"RS256",
+            "kid":"second-rotation",
+            "n":URL_SAFE_NO_PAD.encode(rotated_public.n().to_bytes_be()),
+            "e":URL_SAFE_NO_PAD.encode(rotated_public.e().to_bytes_be())
+        }]});
+        let mut second_header = Header::new(Algorithm::RS256);
+        second_header.kid = Some("second-rotation".into());
+        let second_token = encode(
+            &second_header,
+            &claims,
+            &EncodingKey::from_rsa_pem(rotated_pem.as_bytes()).unwrap(),
+        )
+        .unwrap();
+        assert!(
+            authorizer
+                .authorize(&request_headers(&second_token, "jdx/mise"), Access::Write)
+                .await
                 .is_err()
         );
         authorizer.oidc[0].min_refresh_interval = Duration::ZERO;
         assert!(
             authorizer
-                .authorize(&request_headers(&rotated_token, "jdx/mise"), Access::Write)
+                .authorize(&request_headers(&second_token, "jdx/mise"), Access::Write)
                 .await
                 .is_ok()
         );

--- a/src/config.rs
+++ b/src/config.rs
@@ -51,6 +51,10 @@ pub struct Config {
     #[arg(long, env = "MISE_CACHE_TOKENS_JSON", hide_env_values = true)]
     pub tokens_json: Option<String>,
 
+    /// JSON array of trusted OIDC providers and authorization rules. See README.md.
+    #[arg(long, env = "MISE_CACHE_OIDC_PROVIDERS_JSON", hide_env_values = true)]
+    pub oidc_providers_json: Option<String>,
+
     #[arg(long, env = "MISE_CACHE_ALLOW_ANONYMOUS", default_value_t = false)]
     pub allow_anonymous: bool,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,12 @@ async fn main() -> Result<()> {
     let state = server::AppState::new(
         blobs,
         metadata,
-        auth::Authorizer::new(config.tokens_json.as_deref(), config.allow_anonymous)?,
+        auth::Authorizer::new(
+            config.tokens_json.as_deref(),
+            config.oidc_providers_json.as_deref(),
+            config.allow_anonymous,
+        )
+        .await?,
         config.max_blob_bytes,
     );
     let app = server::router(state);

--- a/src/server.rs
+++ b/src/server.rs
@@ -92,7 +92,7 @@ async fn get_blob(
     headers: HeaderMap,
     Path(parts): Path<(String, String, u64)>,
 ) -> Result<Response, ApiError> {
-    let namespace = state.auth.authorize(&headers, Access::Read)?;
+    let namespace = state.auth.authorize(&headers, Access::Read).await?;
     let digest = parse_digest(parts)?;
     if !state
         .metadata
@@ -125,7 +125,7 @@ async fn put_blob(
     Path(parts): Path<(String, String, u64)>,
     body: Body,
 ) -> Result<StatusCode, ApiError> {
-    let namespace = state.auth.authorize(&headers, Access::Write)?;
+    let namespace = state.auth.authorize(&headers, Access::Write).await?;
     require_immutable_precondition(&headers)?;
     let digest = parse_digest(parts)?;
     if digest.size > state.max_blob_bytes {
@@ -203,7 +203,7 @@ async fn missing_blobs(
     headers: HeaderMap,
     Json(request): Json<MissingRequest>,
 ) -> Result<Json<MissingResponse>, ApiError> {
-    let namespace = state.auth.authorize(&headers, Access::Read)?;
+    let namespace = state.auth.authorize(&headers, Access::Read).await?;
     if request.digests.len() > 10_000 {
         return Err(ApiError::bad_request(
             "at most 10000 digests may be checked",
@@ -229,7 +229,7 @@ async fn get_action_result(
     headers: HeaderMap,
     Path(parts): Path<(String, String, u64)>,
 ) -> Result<Json<ActionResultEnvelope>, ApiError> {
-    let namespace = state.auth.authorize(&headers, Access::Read)?;
+    let namespace = state.auth.authorize(&headers, Access::Read).await?;
     let action = parse_digest(parts)?;
     match state
         .metadata
@@ -254,7 +254,7 @@ async fn put_action_result(
     Path(parts): Path<(String, String, u64)>,
     Json(envelope): Json<ActionResultEnvelope>,
 ) -> Result<StatusCode, ApiError> {
-    let namespace = state.auth.authorize(&headers, Access::Write)?;
+    let namespace = state.auth.authorize(&headers, Access::Write).await?;
     require_immutable_precondition(&headers)?;
     let action = parse_digest(parts)?;
     if envelope.result.version != 1 || envelope.result.action != action {
@@ -566,7 +566,7 @@ mod tests {
         let directory = tempfile::tempdir().unwrap();
         let blobs = Arc::new(FilesystemStore::new(directory.path()).await.unwrap());
         let metadata = Arc::new(MemoryMetadata::default());
-        let auth = Authorizer::new(None, true).unwrap();
+        let auth = Authorizer::new(None, None, true).await.unwrap();
         (
             router(AppState::new(blobs, metadata, auth, 1024 * 1024)),
             directory,


### PR DESCRIPTION
## Summary

- accept short-lived OIDC JWTs alongside static bearer tokens
- discover and cache provider JWKS, refresh stale keys, and retry unknown key IDs for rotation
- validate asymmetric signatures, issuer, audience, expiry, not-before, subject, key use, and signing algorithm
- map exact identity claims to per-namespace read/write grants
- expose provider configuration through the CLI, environment, and optional Helm Secret key
- document GitHub Actions OIDC usage until mise gains automatic token acquisition

## Security model

Provider configuration is deny-by-default: each issuer requires audiences and authorization rules, and each rule requires at least one exact claim constraint. Symmetric JWT algorithms are rejected. Static grants and OIDC providers can coexist during migration.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `mise x helm@3.18.4 -- helm lint charts/mise-cache --set config.databaseUrl=postgres://example --set config.s3Bucket=example`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Expands the security boundary with outbound OIDC/JWKS fetches, JWT validation, and async auth on every protected request; misconfiguration could deny access or grant overly broad namespaces.
> 
> **Overview**
> Adds **OIDC JWT authorization** alongside existing static bearer tokens so CI can use short-lived identity tokens (e.g. GitHub Actions) without long-lived cache secrets.
> 
> **`MISE_CACHE_OIDC_PROVIDERS_JSON`** configures trusted issuers, audiences, and claim-based rules that map to the same namespace read/write patterns as static grants. On startup the service discovers JWKS (with retries), caches keys, refreshes on a schedule or unknown `kid`, and enforces asymmetric algorithms only, standard JWT claims, and deny-by-default rules with at least one claim per rule. Static token matching is unchanged; OIDC is tried when no static grant matches.
> 
> **`Authorizer::new` and `authorize` are async**; cache handlers await authorization. Helm can mount optional `oidc-providers-json` secret key; static tokens secret is also optional. README documents provider options, JWKS behavior, and a GitHub Actions workflow pattern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce2a2a6020833d194cddb49e21b4c1d20011eb7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OIDC bearer-token authorization with provider discovery, JWT validation, claim-based rules, audience checks, and namespace-specific read/write permissions.
  * Added support for configuring trusted OIDC providers through `MISE_CACHE_OIDC_PROVIDERS_JSON`.
  * Added Kubernetes chart configuration for storing OIDC provider settings in a secret.
  * Retained support for static token authorization and anonymous access where configured.

* **Documentation**
  * Documented OIDC configuration, security requirements, JWT validation, JWKS handling, and GitHub Actions usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->