### PR TITLE
chore(release): automate container releases

### DIFF
--- a/.github/workflows/auto-merge-release.yml
+++ b/.github/workflows/auto-merge-release.yml
@@ -1,0 +1,76 @@
+name: auto-merge-release
+
+on:
+  schedule:
+    - cron: "0 10 * * *"
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: auto-merge-release
+  cancel-in-progress: false
+
+jobs:
+  merge:
+    if: github.repository == 'jdx/mise-cache'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: false
+      - name: Merge the release PR
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          if [ "${GITHUB_EVENT_NAME:-}" != "workflow_dispatch" ]; then
+            latest_tag=$(git describe --tags --match 'v[0-9]*' --abbrev=0 || true)
+            if [ -n "$latest_tag" ]; then
+              range="${latest_tag}..HEAD"
+              tag_time=$(git for-each-ref --format='%(creatordate:unix)' "refs/tags/$latest_tag")
+              now=$(date +%s)
+              min_age=$((7 * 24 * 60 * 60))
+              age=$((now - tag_time))
+              if [ "$age" -lt "$min_age" ]; then
+                echo "Latest release ${latest_tag} is less than seven days old"
+                exit 0
+              fi
+
+              commit_subjects=$(git log --format=%s "$range")
+              if ! grep -Eq '^(fix|feat)(\([^)]+\))?!?: ' <<<"$commit_subjects"; then
+                echo "No pending fix or feat commits since ${latest_tag}"
+                exit 0
+              fi
+            else
+              echo "No release tag found; allowing the initial release"
+            fi
+          else
+            echo "Manual dispatch; skipping release cadence guards"
+          fi
+
+          pr_number=$(gh pr list \
+            --repo jdx/mise-cache \
+            --base main \
+            --state open \
+            --limit 100 \
+            --json number,headRefName,headRepositoryOwner,title,updatedAt \
+            --jq '[.[] | select(.headRefName | startswith("release-plz-")) | select(.headRepositoryOwner.login == "jdx") | select(.title | startswith("chore: release"))] | sort_by(.updatedAt) | reverse | .[0].number // empty')
+          if [ -z "$pr_number" ]; then
+            echo "No open release-plz PR to main"
+            exit 0
+          fi
+
+          body=$(gh pr view "$pr_number" --repo jdx/mise-cache --json body --jq '.body // ""')
+          if [ -z "$(tr -d '[:space:]' <<<"$body")" ]; then
+            echo "Release PR #${pr_number} has an empty body; retrying later"
+            exit 0
+          fi
+
+          echo "Release PR #${pr_number} is ready for the release window"
+          gh pr merge "$pr_number" --repo jdx/mise-cache --squash --auto

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,0 +1,88 @@
+name: release-plz
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  release:
+    name: Release
+    if: github.repository == 'jdx/mise-cache'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
+    outputs:
+      tag: ${{ steps.mise-cache-tag.outputs.tag }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - id: release-plz
+        uses: release-plz/action@2eb1d8bcb770b4c48ccfaad919734b38b51958c9 # v0.5.131
+        with:
+          command: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+      - name: Find the mise-cache tag
+        id: mise-cache-tag
+        env:
+          RELEASES: ${{ steps.release-plz.outputs.releases }}
+        run: |
+          tag=""
+          if [ -n "$RELEASES" ]; then
+            tag=$(jq -r '[.[] | select(.package_name == "mise-cache")][0].tag // ""' <<<"$RELEASES")
+          fi
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "mise-cache tag: ${tag:-<none released>}"
+
+  image:
+    name: Publish container image
+    needs: release
+    if: needs.release.outputs.tag != ''
+    permissions:
+      contents: write
+      id-token: write
+      packages: write
+    uses: ./.github/workflows/release.yml
+    with:
+      tag: ${{ needs.release.outputs.tag }}
+
+  publish-release:
+    name: Publish GitHub release
+    needs: [release, image]
+    if: needs.release.outputs.tag != ''
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.release.outputs.tag }}
+        run: gh release edit "$TAG" --repo "${{ github.repository }}" --draft=false
+
+  release-pr:
+    name: Release PR
+    if: github.repository == 'jdx/mise-cache'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    concurrency:
+      group: release-plz-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: release-plz/action@2eb1d8bcb770b4c48ccfaad919734b38b51958c9 # v0.5.131
+        with:
+          command: release-pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,31 +1,53 @@
-name: Release
+name: release
+
 on:
-  push:
-    tags: ["v*"]
-permissions:
-  contents: read
-  packages: write
-  id-token: write
+  workflow_call:
+    inputs:
+      tag:
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing release tag to rebuild, e.g. v0.1.0"
+        required: true
+        type: string
+
+permissions: {}
+
 jobs:
   image:
+    name: Publish container image
+    if: github.repository == 'jdx/mise-cache'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+      packages: write
     steps:
-      - uses: actions/checkout@v5
-      - uses: docker/setup-buildx-action@v4
-      - uses: docker/login-action@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.tag }}
+          persist-credentials: false
+      - name: Resolve source commit
+        id: source
+        run: echo "short-sha=$(git rev-parse --short=7 HEAD)" >> "$GITHUB_OUTPUT"
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/metadata-action@v6
+      - uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         id: meta
         with:
           images: ghcr.io/jdx/mise-cache
           tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=sha
-      - uses: docker/build-push-action@v7
+            type=semver,pattern={{version}},value=${{ inputs.tag }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ inputs.tag }}
+            type=raw,value=sha-${{ steps.source.outputs.short-sha }}
+      - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        id: push
         with:
           context: .
           push: true
@@ -36,3 +58,21 @@ jobs:
           cache-to: type=gha,mode=max
           provenance: mode=max
           sbom: true
+      - name: Record immutable image reference
+        env:
+          DIGEST: ${{ steps.push.outputs.digest }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ inputs.tag }}
+        run: |
+          image="ghcr.io/jdx/mise-cache@$DIGEST"
+          printf '%s\n' "$image" | tee container-image.txt
+          printf '### Container image\n\n%s\n' "$image" >> "$GITHUB_STEP_SUMMARY"
+          gh release upload "$TAG" container-image.txt \
+            --repo "${{ github.repository }}" \
+            --clobber
+      - name: Publish manually recovered release
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ inputs.tag }}
+        run: gh release edit "$TAG" --repo "${{ github.repository }}" --draft=false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 license = "MIT"
 description = "Self-hosted remote task cache for mise"
 repository = "https://github.com/jdx/mise-cache"
+publish = false
 
 [dependencies]
 anyhow = "1"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,32 @@
+# Releasing mise-cache
+
+Releases are managed by release-plz. It derives versions from Git tags, updates
+`Cargo.toml` and `CHANGELOG.md` in a release PR, and never publishes the service
+to crates.io.
+
+## Repository setup
+
+Create a `RELEASE_PLZ_TOKEN` Actions secret containing a fine-grained GitHub
+token for this repository with read/write access to contents and pull requests.
+A token distinct from `GITHUB_TOKEN` is required so release-plz's pull requests
+trigger the normal CI and review workflows.
+
+## Normal release flow
+
+1. A push to `main` opens or updates the release-plz release PR.
+2. The daily release job enables auto-merge when the previous release is at
+   least seven days old and a `feat` or `fix` commit is pending. The first
+   release is allowed immediately. Manually dispatch `auto-merge-release` to
+   bypass the cadence checks.
+3. Merging the release PR creates a `vX.Y.Z` tag and draft GitHub release.
+4. The release workflow publishes the multi-platform image, uploads its
+   immutable reference as `container-image.txt`, and publishes the release.
+
+The image reference in `container-image.txt` is the value to use for
+`MISE_CACHE_IMAGE` in the OVH deployment.
+
+## Recovery
+
+If image publishing fails after a tag exists, manually dispatch the `release`
+workflow with that tag. It rebuilds the image, replaces `container-image.txt`,
+and publishes the release only after the image succeeds.

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,5 @@
+[workspace]
+git_only = true
+release_always = false
+git_release_enable = true
+git_release_draft = true


### PR DESCRIPTION
## Summary
- manage mise-cache versions, changelogs, tags, and draft GitHub releases with release-plz in Git-only mode
- publish the multi-platform GHCR image through a reusable workflow and attach its immutable digest to each release
- publish releases only after the image succeeds, with manual recovery for an existing tag
- auto-merge release PRs on a seven-day cadence when `feat` or `fix` changes are pending, while allowing the initial release immediately
- prevent accidental crates.io publication and document the required repository token and recovery flow
- pin every action introduced or changed in the release supply chain to a full commit SHA

## Validation
- `actionlint .github/workflows/*.yml`
- `release-plz release --dry-run --allow-dirty --git-token ... --forge github --output json`
- `release-plz update` in an isolated repository copy (initial `v0.1.0` and changelog generation)
- `cargo metadata --no-deps --format-version 1`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `docker build --tag mise-cache:release-plz-validation .`
- `zizmor .github/workflows --format plain` (new and modified release workflows clean; existing CI pins reported separately)

## Repository setup
Add a `RELEASE_PLZ_TOKEN` Actions secret with read/write access to repository contents and pull requests before merging. A non-`GITHUB_TOKEN` credential ensures release-plz pull requests trigger the normal CI and review workflows.

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how production container images and GitHub releases are produced and can auto-merge release PRs; misconfiguration of tokens or cadence logic could ship releases unexpectedly, though scope is CI/release automation only.
> 
> **Overview**
> Replaces tag-push-only GHCR publishing with a **release-plz** Git-only pipeline: versions, changelog, draft GitHub releases, and tags, without crates.io (`publish = false` in `Cargo.toml`, `release-plz.toml`).
> 
> **`release-plz.yml`** on `main` opens/updates release PRs, runs `release` when a release PR merges, calls reusable **`release.yml`** for multi-arch images, uploads **`container-image.txt`** (digest reference for `MISE_CACHE_IMAGE`), and only then undrafts the GitHub release. **`release.yml`** is now `workflow_call` / manual dispatch with a required tag (not `push: tags`), pins actions to commit SHAs, and supports recovery rebuilds.
> 
> **`auto-merge-release.yml`** runs daily (or on dispatch) to squash auto-merge the latest open `release-plz` PR when the prior tag is ≥7 days old and pending `feat`/`fix` commits exist (first release and manual dispatch skip cadence guards).
> 
> **`RELEASING.md`** documents `RELEASE_PLZ_TOKEN`, the flow, and manual image recovery.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0a90fc8b9ade482838da35a7e3fd4fe5b7a5e4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated release management for creating, updating, and merging release pull requests.
  * Added automated multi-architecture container image publishing with version and commit-based tags.
  * Added safeguards and recovery support for release publishing.

* **Documentation**
  * Added release process documentation, including setup, permissions, image references, and recovery steps.

* **Chores**
  * Disabled package registry publication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->