### PR TITLE
chore: release v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/jdx/mise-cache/releases/tag/v0.1.0) - 2026-08-07
+
+### Added
+
+- *(deploy)* add OVH US production configuration ([#2](https://github.com/jdx/mise-cache/pull/2))
+- *(auth)* add OIDC bearer authorization ([#1](https://github.com/jdx/mise-cache/pull/1))
+- add self-hosted mise cache service
+
+### Fixed
+
+- *(release)* harden and streamline release CI ([#5](https://github.com/jdx/mise-cache/pull/5))
+
+### Other
+
+- *(release)* automate container releases ([#3](https://github.com/jdx/mise-cache/pull/3))
+- *(ci)* update docker actions
+- *(ci)* cache container build layers
+- *(ci)* update checkout action


### PR DESCRIPTION



## 🤖 New release

* `mise-cache`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.0](https://github.com/jdx/mise-cache/releases/tag/v0.1.0) - 2026-08-07

### Added

- *(deploy)* add OVH US production configuration ([#2](https://github.com/jdx/mise-cache/pull/2))
- *(auth)* add OIDC bearer authorization ([#1](https://github.com/jdx/mise-cache/pull/1))
- add self-hosted mise cache service

### Fixed

- *(release)* harden and streamline release CI ([#5](https://github.com/jdx/mise-cache/pull/5))

### Other

- *(release)* automate container releases ([#3](https://github.com/jdx/mise-cache/pull/3))
- *(ci)* update docker actions
- *(ci)* cache container build layers
- *(ci)* update checkout action
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog for an automated release; no runtime or security behavior changes in the diff.
> 
> **Overview**
> Introduces **`CHANGELOG.md`** (Keep a Changelog format) and records **v0.1.0** (2026-08-07), leaving an empty **`[Unreleased]`** section for future entries.
> 
> The **0.1.0** notes summarize what shipped in this first release: self-hosted mise cache service, OIDC bearer auth, OVH US production deploy config, release/container CI improvements, and related CI updates—without changing application code in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9b46d836227f80702e9464710a56d30fbad349d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->