### PR TITLE
chore(release): publish crates.io releases

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
       pull-requests: read
     outputs:
       tag: ${{ steps.mise-cache-tag.outputs.tag }}
@@ -39,6 +40,18 @@ jobs:
           fi
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
           echo "mise-cache tag: ${tag:-<none released>}"
+      - name: Reject an empty release result for a merged release PR
+        if: steps.mise-cache-tag.outputs.tag == ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          release_pr=$(gh api \
+            "repos/${{ github.repository }}/commits/${{ github.sha }}/pulls" \
+            --jq '[.[] | select(.merged_at != null) | select(.head.ref | startswith("release-plz-"))][0].number // ""')
+          if [ -n "$release_pr" ]; then
+            echo "::error::release-plz returned no release after merging release PR #$release_pr"
+            exit 1
+          fi
 
   image:
     name: Publish container image

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,18 @@ edition = "2024"
 license = "MIT"
 description = "Self-hosted remote task cache for mise"
 repository = "https://github.com/jdx/mise-cache"
-publish = false
+homepage = "https://github.com/jdx/mise-cache"
+readme = "README.md"
+keywords = ["mise", "cache", "build-cache", "remote-cache"]
+categories = ["command-line-utilities", "development-tools"]
+include = [
+  "/src/**",
+  "/migrations/**",
+  "/Cargo.toml",
+  "/Cargo.lock",
+  "/README.md",
+  "/LICENSE",
+]
 
 [dependencies]
 anyhow = "1"

--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@
 
 ## Quick start
 
+Install the service from crates.io:
+
+```sh
+cargo install mise-cache
+```
+
 The development stack starts the service, PostgreSQL, and MinIO:
 
 ```sh

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,8 +1,8 @@
 # Releasing mise-cache
 
-Releases are managed by release-plz. It derives versions from Git tags, updates
-`Cargo.toml` and `CHANGELOG.md` in a release PR, and never publishes the service
-to crates.io.
+Releases are managed by release-plz. It derives versions from crates.io and
+updates `Cargo.toml` and `CHANGELOG.md` in a release PR. Merging that PR
+publishes the crate, Git tag, GitHub release, and container image.
 
 ## Repository setup
 
@@ -11,6 +11,11 @@ token for this repository with read/write access to contents and pull requests.
 A token distinct from `GITHUB_TOKEN` is required so release-plz's pull requests
 trigger the normal CI and review workflows.
 
+Configure a crates.io trusted publisher for owner `jdx`, repository
+`mise-cache`, and workflow `release-plz.yml`. The release job requests a
+short-lived crates.io token with GitHub OIDC; no long-lived crates.io token is
+stored in GitHub.
+
 ## Normal release flow
 
 1. A push to `main` opens or updates the release-plz release PR.
@@ -18,7 +23,8 @@ trigger the normal CI and review workflows.
    least seven days old and a `feat` or `fix` commit is pending. The first
    release is allowed immediately. Manually dispatch `auto-merge-release` to
    bypass the cadence checks.
-3. Merging the release PR creates a `vX.Y.Z` tag and draft GitHub release.
+3. Merging the release PR publishes the crate to crates.io and creates a
+   `vX.Y.Z` tag and draft GitHub release.
 4. The release workflow publishes the multi-platform image, uploads its
    immutable reference as `container-image.txt`, and publishes the release.
 

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,5 +1,4 @@
 [workspace]
-git_only = true
 release_always = false
 git_release_enable = true
 git_release_draft = true


### PR DESCRIPTION
## Summary

- publish `mise-cache` releases to crates.io through release-plz and trusted publishing
- package only the service source, embedded migration, and user-facing metadata
- fail the release job when a merged release PR unexpectedly produces no release
- document crates.io installation and the OIDC-based release setup

## Why

The first release PR completed successfully without creating a tag, GitHub release, or container image because `publish = false` caused release-plz to exclude the package entirely. A `0.0.0` bootstrap crate now exists, so crates.io can be the release source of truth and GitHub OIDC can provide short-lived publishing credentials.

## Validation

- `cargo fmt --check`
- `cargo publish --dry-run --allow-dirty`
- `cargo package --list --allow-dirty`
- `mise x actionlint@1.7.7 -- actionlint -shellcheck= .github/workflows/*.yml`
- `cargo test`
- `mise x release-plz@0.3.160 -- release-plz update -vv` (confirmed `0.0.0 -> 0.1.0` and an already up-to-date release tree)

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release pipeline and public crate publishing surface; mitigated by OIDC trusted publishing and an explicit guard against empty releases after merge.
> 
> **Overview**
> **Enables crates.io publishing** for `mise-cache` by removing `publish = false` and release-plz’s `git_only` mode, and by granting **`id-token: write`** on the release job for crates.io **trusted publishing** (no long-lived token in GitHub).
> 
> **Cargo packaging** is tightened with homepage/readme/keywords/categories and an explicit `include` list (source, migrations, lockfile, docs).
> 
> The **release workflow** now **fails** when a merged `release-plz-*` PR yields no tag/release, avoiding silent “successful” merges with no artifact. **README** adds `cargo install mise-cache`; **RELEASING.md** documents OIDC setup and the updated release flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ae049abad8bc11dd1811765dd188e4d0468c646. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->