### PR TITLE
chore(ci): publish images from main

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -5,16 +5,8 @@ on:
     paths:
       - .dockerignore
       - .github/workflows/container.yml
-      - Cargo.lock
-      - Cargo.toml
-      - Dockerfile
-      - migrations/**
-      - src/**
-  push:
-    branches: [main]
-    paths:
-      - .dockerignore
-      - .github/workflows/container.yml
+      - .github/workflows/release-plz.yml
+      - .github/workflows/release.yml
       - Cargo.lock
       - Cargo.toml
       - Dockerfile

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -56,14 +56,15 @@ jobs:
   image:
     name: Publish container image
     needs: release
-    if: needs.release.outputs.tag != ''
     permissions:
       contents: write
       id-token: write
       packages: write
     uses: ./.github/workflows/release.yml
     with:
+      ref: ${{ github.sha }}
       tag: ${{ needs.release.outputs.tag }}
+      publish_main: true
 
   publish-release:
     name: Publish GitHub release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,9 +3,21 @@ name: release
 on:
   workflow_call:
     inputs:
-      tag:
+      ref:
         required: true
         type: string
+      tag:
+        required: false
+        type: string
+        default: ""
+      publish_main:
+        required: false
+        type: boolean
+        default: false
+    outputs:
+      digest:
+        description: Published multi-platform image digest
+        value: ${{ jobs.image.outputs.digest }}
   workflow_dispatch:
     inputs:
       tag:
@@ -20,6 +32,8 @@ jobs:
     name: Publish container image
     if: github.repository == 'jdx/mise-cache'
     runs-on: ubuntu-latest
+    outputs:
+      digest: ${{ steps.push.outputs.digest }}
     permissions:
       contents: write
       id-token: write
@@ -27,11 +41,11 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ inputs.tag }}
+          ref: ${{ inputs.ref || inputs.tag }}
           persist-credentials: false
       - name: Resolve source commit
         id: source
-        run: echo "short-sha=$(git rev-parse --short=7 HEAD)" >> "$GITHUB_OUTPUT"
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
@@ -42,10 +56,11 @@ jobs:
         id: meta
         with:
           images: ghcr.io/jdx/mise-cache
+          flavor: latest=false
           tags: |
-            type=semver,pattern={{version}},value=${{ inputs.tag }}
-            type=semver,pattern={{major}}.{{minor}},value=${{ inputs.tag }}
-            type=raw,value=sha-${{ steps.source.outputs.short-sha }}
+            type=raw,value=sha-${{ steps.source.outputs.sha }}
+            type=semver,pattern={{version}},value=${{ inputs.tag }},enable=${{ inputs.tag != '' }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ inputs.tag }},enable=${{ inputs.tag != '' }}
       - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         id: push
         with:
@@ -58,15 +73,35 @@ jobs:
           cache-to: type=gha,mode=max
           provenance: mode=max
           sbom: true
-      - name: Record immutable image reference
+      - name: Promote the newest main image
+        if: inputs.publish_main
         env:
           DIGEST: ${{ steps.push.outputs.digest }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ inputs.tag }}
+          SOURCE_SHA: ${{ steps.source.outputs.sha }}
+        run: |
+          latest_sha=$(gh api "repos/${{ github.repository }}/commits/main" --jq .sha)
+          if [ "$SOURCE_SHA" = "$latest_sha" ]; then
+            docker buildx imagetools create \
+              --tag ghcr.io/jdx/mise-cache:main \
+              "ghcr.io/jdx/mise-cache@$DIGEST"
+            echo "Promoted $SOURCE_SHA to ghcr.io/jdx/mise-cache:main" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "Skipped main promotion because $SOURCE_SHA is no longer the head of main." >> "$GITHUB_STEP_SUMMARY"
+          fi
+      - name: Record immutable image reference
+        env:
+          DIGEST: ${{ steps.push.outputs.digest }}
         run: |
           image="ghcr.io/jdx/mise-cache@$DIGEST"
           printf '%s\n' "$image" | tee container-image.txt
           printf '### Container image\n\n%s\n' "$image" >> "$GITHUB_STEP_SUMMARY"
+      - name: Attach image reference to release
+        if: inputs.tag != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ inputs.tag }}
+        run: |
           if ! gh release view "$TAG" --repo "${{ github.repository }}" >/dev/null 2>&1; then
             gh release create "$TAG" \
               --repo "${{ github.repository }}" \
@@ -79,7 +114,7 @@ jobs:
             --repo "${{ github.repository }}" \
             --clobber
       - name: Publish manually recovered release
-        if: github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'workflow_dispatch' && inputs.tag != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ inputs.tag }}

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,8 +1,9 @@
 # Releasing mise-cache
 
 Releases are managed by release-plz. It derives versions from crates.io and
-updates `Cargo.toml` and `CHANGELOG.md` in a release PR. Merging that PR
-publishes the crate, Git tag, GitHub release, and container image.
+updates `Cargo.toml` and `CHANGELOG.md` in a release PR. Every commit on `main`
+publishes a container image. Merging a release PR additionally publishes the
+crate, Git tag, and GitHub release.
 
 ## Repository setup
 
@@ -18,15 +19,19 @@ stored in GitHub.
 
 ## Normal release flow
 
-1. A push to `main` opens or updates the release-plz release PR.
-2. The daily release job enables auto-merge when the previous release is at
+1. Every push to `main` publishes a multi-platform image tagged with the full
+   commit SHA (`sha-<commit>`) and moves `main` to that image. If builds overlap,
+   only the current head commit is allowed to move `main`.
+2. A push to `main` also opens or updates the release-plz release PR.
+3. The daily release job enables auto-merge when the previous release is at
    least seven days old and a `feat` or `fix` commit is pending. The first
    release is allowed immediately. Manually dispatch `auto-merge-release` to
    bypass the cadence checks.
-3. Merging the release PR publishes the crate to crates.io and creates a
+4. Merging the release PR publishes the crate to crates.io and creates a
    `vX.Y.Z` tag and draft GitHub release.
-4. The release workflow publishes the multi-platform image, uploads its
-   immutable reference as `container-image.txt`, and publishes the release.
+5. The same image build also adds the `X.Y.Z` and `X.Y` tags, uploads its
+   immutable digest reference as `container-image.txt`, and publishes the
+   release. A second container build is not run for the release.
 
 The image reference in `container-image.txt` is the value to use for
 `MISE_CACHE_IMAGE` in the OVH deployment.
@@ -35,4 +40,5 @@ The image reference in `container-image.txt` is the value to use for
 
 If image publishing fails after a tag exists, manually dispatch the `release`
 workflow with that tag. It rebuilds the image, replaces `container-image.txt`,
-and publishes the release only after the image succeeds.
+and publishes the release only after the image succeeds. Recovery does not move
+the `main` image tag.


### PR DESCRIPTION
## Summary
- publish a multi-platform GHCR image for every commit pushed to `main`
- tag every build with its full commit SHA and safely promote only the newest commit to `main`
- apply release version tags to the same image build and expose the digest for follow-up deployment automation
- keep pull-request image validation while removing the redundant post-merge validation build

## Validation
- `mise x actionlint@1.7.7 shellcheck@0.11.0 -- actionlint .github/workflows/*.yml`
- `git diff --check`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes deployment-facing CI (when images publish and which tags move), though promotion is guarded against stale `main` updates; mistakes could affect what OVH pulls via `MISE_CACHE_IMAGE` or `:main`.
> 
> **Overview**
> **Every push to `main` now publishes a multi-platform GHCR image** via `release-plz.yml` calling the reusable `release.yml`, instead of only building images when a release tag exists or on a separate `container` push workflow.
> 
> The reusable **release** workflow takes a required **`ref`**, optional **`tag`**, and **`publish_main`**. Builds always tag **`sha-<full commit>`**; semver **`X.Y.Z` / `X.Y`** tags apply only when a release tag is set. With **`publish_main`**, **`ghcr.io/jdx/mise-cache:main`** is updated via `imagetools` only if that commit is still the head of `main`, so overlapping builds cannot roll `main` backward.
> 
> Release-specific steps (draft release, `container-image.txt` upload, manual publish) run only when **`tag` is non-empty**; recovery dispatch does not move **`main`**. **`container.yml`** drops the **`push` to `main`** trigger (PR validation only) and watches the release workflows in path filters. **`RELEASING.md`** documents the new per-commit image flow and single-build release tagging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4451459d22fee87b7cf8de75e42faadb3eeeeeee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Images can now be published immediately from the latest `main` commit.
  * Release builds can reuse the same image and expose its published digest.
  * Image promotion to the `main` tag is guarded against outdated commits.

* **Bug Fixes**
  * Release workflows now handle tagged and untagged builds more reliably.
  * Release attachments are created only when a release tag is available.

* **Documentation**
  * Updated release and recovery guidance to reflect the new publishing flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->