### PR TITLE
perf(ci): build container images natively

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ on:
     outputs:
       digest:
         description: Published multi-platform image digest
-        value: ${{ jobs.image.outputs.digest }}
+        value: ${{ jobs.merge.outputs.digest }}
   workflow_dispatch:
     inputs:
       tag:
@@ -28,16 +28,15 @@ on:
 permissions: {}
 
 jobs:
-  image:
-    name: Publish container image
+  prepare:
+    name: Prepare container image
     if: github.repository == 'jdx/mise-cache'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
-      digest: ${{ steps.push.outputs.digest }}
+      sha: ${{ steps.source.outputs.sha }}
     permissions:
-      contents: write
-      id-token: write
-      packages: write
+      contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -46,6 +45,31 @@ jobs:
       - name: Resolve source commit
         id: source
         run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+  build:
+    name: Build ${{ matrix.platform }} container image
+    needs: prepare
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-24.04
+            artifact: amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            artifact: arm64
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.prepare.outputs.sha }}
+          persist-credentials: false
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
@@ -58,27 +82,116 @@ jobs:
           images: ghcr.io/jdx/mise-cache
           flavor: latest=false
           tags: |
-            type=raw,value=sha-${{ steps.source.outputs.sha }}
-            type=semver,pattern={{version}},value=${{ inputs.tag }},enable=${{ inputs.tag != '' }}
-            type=semver,pattern={{major}}.{{minor}},value=${{ inputs.tag }},enable=${{ inputs.tag != '' }}
+            type=raw,value=sha-${{ needs.prepare.outputs.sha }}
       - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         id: push
         with:
           context: .
           push: true
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta.outputs.tags }}
+          platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          outputs: type=image,name=ghcr.io/jdx/mise-cache,push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=image-${{ matrix.artifact }}
+          cache-to: type=gha,mode=max,scope=image-${{ matrix.artifact }}
           provenance: mode=max
           sbom: true
+      - name: Export image digest
+        env:
+          DIGEST: ${{ steps.push.outputs.digest }}
+        run: |
+          if [[ ! "$DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "::error::Unable to resolve the platform image digest: $DIGEST"
+            exit 1
+          fi
+          mkdir -p /tmp/digests
+          touch "/tmp/digests/${DIGEST#sha256:}"
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: digests-${{ matrix.artifact }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    name: Publish multi-platform container image
+    needs: [prepare, build]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      digest: ${{ steps.manifest.outputs.digest }}
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
+        id: meta
+        with:
+          images: ghcr.io/jdx/mise-cache
+          flavor: latest=false
+          tags: |
+            type=raw,value=sha-${{ needs.prepare.outputs.sha }}
+            type=semver,pattern={{version}},value=${{ inputs.tag }},enable=${{ inputs.tag != '' }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ inputs.tag }},enable=${{ inputs.tag != '' }}
+      - name: Create multi-platform manifest
+        id: manifest
+        env:
+          REGISTRY_IMAGE: ghcr.io/jdx/mise-cache
+          SOURCE_SHA: ${{ needs.prepare.outputs.sha }}
+          TAGS: ${{ steps.meta.outputs.tags }}
+        working-directory: /tmp/digests
+        run: |
+          tag_args=()
+          while IFS= read -r tag; do
+            tag_args+=(--tag "$tag")
+          done <<< "$TAGS"
+
+          sources=()
+          for digest in *; do
+            if [[ ! "$digest" =~ ^[0-9a-f]{64}$ ]]; then
+              echo "::error::Invalid platform image digest: $digest"
+              exit 1
+            fi
+            sources+=("$REGISTRY_IMAGE@sha256:$digest")
+          done
+          if (( ${#sources[@]} != 2 )); then
+            echo "::error::Expected two platform image digests, found ${#sources[@]}"
+            exit 1
+          fi
+
+          docker buildx imagetools create "${tag_args[@]}" "${sources[@]}"
+          manifest=$(docker buildx imagetools inspect \
+            "$REGISTRY_IMAGE:sha-$SOURCE_SHA" \
+            --format '{{json .Manifest}}')
+          digest=$(jq -r .digest <<< "$manifest")
+          if [[ ! "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "::error::Unable to resolve the published manifest digest: $digest"
+            exit 1
+          fi
+          platforms=$(jq -r \
+            '[.manifests[] | select(.platform.os == "linux") | .platform.os + "/" + .platform.architecture] | unique | sort | join(",")' \
+            <<< "$manifest")
+          if [ "$platforms" != "linux/amd64,linux/arm64" ]; then
+            echo "::error::Unexpected published platforms: $platforms"
+            exit 1
+          fi
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
       - name: Promote the newest main image
         if: inputs.publish_main
         env:
-          DIGEST: ${{ steps.push.outputs.digest }}
+          DIGEST: ${{ steps.manifest.outputs.digest }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SOURCE_SHA: ${{ steps.source.outputs.sha }}
+          SOURCE_SHA: ${{ needs.prepare.outputs.sha }}
         run: |
           latest_sha=$(gh api "repos/${{ github.repository }}/commits/main" --jq .sha)
           if [ "$SOURCE_SHA" = "$latest_sha" ]; then
@@ -91,7 +204,7 @@ jobs:
           fi
       - name: Record immutable image reference
         env:
-          DIGEST: ${{ steps.push.outputs.digest }}
+          DIGEST: ${{ steps.manifest.outputs.digest }}
         run: |
           image="ghcr.io/jdx/mise-cache@$DIGEST"
           printf '%s\n' "$image" | tee container-image.txt

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -19,9 +19,11 @@ stored in GitHub.
 
 ## Normal release flow
 
-1. Every push to `main` publishes a multi-platform image tagged with the full
-   commit SHA (`sha-<commit>`) and moves `main` to that image. If builds overlap,
-   only the current head commit is allowed to move `main`.
+1. Every push to `main` builds AMD64 and ARM64 images on native GitHub-hosted
+   runners, combines them into a multi-platform image tagged with the full
+   commit SHA (`sha-<commit>`), and moves `main` to that image. Architecture-
+   specific caches keep subsequent builds fast. If builds overlap, only the
+   current head commit is allowed to move `main`.
 2. A push to `main` also opens or updates the release-plz release PR.
 3. The daily release job enables auto-merge when the previous release is at
    least seven days old and a `feat` or `fix` commit is pending. The first


### PR DESCRIPTION
## Summary
- build AMD64 and ARM64 images concurrently on native GitHub-hosted runners
- push architecture images by digest and assemble one tagged multi-platform manifest
- scope build caches per architecture and cap native builds at 30 minutes
- validate platform digests and the final manifest before promotion or release publication

## Why
The existing multi-platform Docker build compiles the ARM64 Rust binary through QEMU on an AMD64 runner. The first production build remained in that step for over an hour, making publish-on-every-main and automatic deployment impractical.

The final immutable digest, release tags, guarded `main` promotion, provenance, SBOM, and recovery behavior remain intact.

## Validation
- `mise x actionlint@1.7.7 shellcheck@0.11.0 -- actionlint .github/workflows/*.yml`
- `git diff --check`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how production images are built and tagged; mistakes in manifest merge or digest validation could publish incomplete or wrong-platform images, though the new guards mirror the prior promotion/release behavior.
> 
> **Overview**
> Replaces the single-job **multi-platform Docker build** (ARM64 via QEMU on one runner) with a **three-job pipeline**: resolve the source SHA, build **linux/amd64** and **linux/arm64** in parallel on **native** runners (`ubuntu-24.04` / `ubuntu-24.04-arm`), then **merge** platform images into one tagged manifest with `docker buildx imagetools`.
> 
> Per-arch builds use **`push-by-digest`**, upload digest artifacts, and **scoped GHA caches** (`image-amd64` / `image-arm64`); semver and `sha-*` tagging move to the merge job. The workflow adds **digest and platform checks** (exactly two digests, `linux/amd64,linux/arm64`) before promotion, `container-image.txt`, and release upload; the callable workflow **`digest` output** now comes from **`jobs.merge`**. **`RELEASING.md`** documents native per-arch builds and architecture-specific caches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7c1510df77e26bac79a4574355dec31cf61ffd3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->