### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/jdx/mise-cache/compare/v0.1.0...v0.1.1) - 2026-08-10
+
+### Added
+
+- *(protocol)* add mutable action manifests ([#14](https://github.com/jdx/mise-cache/pull/14))
+- *(protocol)* add rustc action contract ([#12](https://github.com/jdx/mise-cache/pull/12))
+
+### Fixed
+
+- *(database)* use unique action manifest migration version ([#18](https://github.com/jdx/mise-cache/pull/18))
+- *(protocol)* align action cache v1 contract ([#10](https://github.com/jdx/mise-cache/pull/10))
+
 ## [0.1.0](https://github.com/jdx/mise-cache/releases/tag/v0.1.0) - 2026-08-07
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1807,7 +1807,7 @@ dependencies = [
 
 [[package]]
 name = "mise-cache"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mise-cache"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 license = "MIT"
 description = "Self-hosted remote build cache for mise"


### PR DESCRIPTION



## 🤖 New release

* `mise-cache`: 0.1.0 -> 0.1.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1](https://github.com/jdx/mise-cache/compare/v0.1.0...v0.1.1) - 2026-08-10

### Added

- *(protocol)* add mutable action manifests ([#14](https://github.com/jdx/mise-cache/pull/14))
- *(protocol)* add rustc action contract ([#12](https://github.com/jdx/mise-cache/pull/12))

### Fixed

- *(database)* use unique action manifest migration version ([#18](https://github.com/jdx/mise-cache/pull/18))
- *(protocol)* align action cache v1 contract ([#10](https://github.com/jdx/mise-cache/pull/10))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only version and changelog updates with no logic or config changes in the diff.
> 
> **Overview**
> **Release-only PR** that bumps `mise-cache` from **0.1.0** to **0.1.1** in `Cargo.toml` and `Cargo.lock`, and adds a **0.1.1** section to `CHANGELOG.md` (dated 2026-08-10).
> 
> The changelog text records work already landed on the default branch—not new code in this diff: protocol additions (mutable action manifests, rustc action contract), fixes (unique action manifest migration version, action cache v1 contract alignment).
> 
> No application or migration source files change here; this is the release-plz packaging step for publishing **v0.1.1**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4dc1b8ce02f657b3d214ff343b7a994e33d7aad1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->