### PR TITLE
feat(protocol): add rustc action contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ All cache requests send `Mise-Cache-Namespace` and, unless anonymous access is e
 
 Blobs and action results are immutable. Repeating an identical write is idempotent; attempting to replace an existing action result returns `409 Conflict`. The server verifies uploaded content and all referenced blobs before publishing an action result.
 
-`GET /v1/capabilities` advertises the action kinds and exact schema versions accepted by the server. Action-result keys use BLAKE3. Version 1 currently accepts task action and metadata schema version 1; compiler and build-system kinds are added through capability negotiation as their schemas ship.
+`GET /v1/capabilities` advertises the action kinds and exact schema versions accepted by the server. Action-result keys use BLAKE3. Version 1 accepts task and rustc action and metadata schema version 1. Rustc results require an output directory tree plus metadata referencing raw stdout and stderr blobs so clients can replay compiler diagnostics byte-for-byte.
 
 ## Operations
 

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ All cache requests send `Mise-Cache-Namespace` and, unless anonymous access is e
 - `GET|PUT /v1/action-results/{algorithm}/{hash}/{size}`
 - `GET /metrics`
 
-Blobs and action results are immutable. Repeating an identical write is idempotent; attempting to replace an existing action result returns `409 Conflict`. The server verifies uploaded content and all referenced blobs before publishing an action result.
+Blobs and action results are immutable. Repeating an identical write is idempotent; attempting to replace an existing action result returns `409 Conflict`. The server verifies uploaded content and every blob reachable from result metadata and output trees before publishing an action result. Content digests inside an action descriptor identify local inputs for key construction; they are not CAS references, and clients do not upload source inputs.
 
 `GET /v1/capabilities` advertises the action kinds and exact schema versions accepted by the server. Action-result keys use BLAKE3. Version 1 accepts task and rustc action and metadata schema version 1. Rustc results require an output directory tree plus metadata referencing raw stdout and stderr blobs so clients can replay compiler diagnostics byte-for-byte.
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -175,6 +175,8 @@ pub struct RustcCompiler {
 #[serde(deny_unknown_fields)]
 pub struct RustcInput {
     pub path: String,
+    /// Identifies local input content for the action key. This is not a CAS
+    /// reference: compiler source inputs are never uploaded to the service.
     pub digest: Digest,
 }
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,5 +1,8 @@
 use serde::{Deserialize, Serialize};
-use std::{collections::BTreeMap, fmt};
+use std::{
+    collections::{BTreeMap, HashSet},
+    fmt,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -148,6 +151,42 @@ pub enum TaskOutputStream {
     Stderr,
 }
 
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RustcAction {
+    pub version: u8,
+    pub kind: String,
+    pub adapter_version: u8,
+    pub compiler: RustcCompiler,
+    pub arguments: Vec<String>,
+    pub environment: BTreeMap<String, Option<String>>,
+    pub inputs: Vec<RustcInput>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RustcCompiler {
+    pub toolchain: String,
+    pub rustc_version: String,
+    pub host: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RustcInput {
+    pub path: String,
+    pub digest: Digest,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RustcMetadata {
+    pub version: u8,
+    pub kind: String,
+    pub stdout: Digest,
+    pub stderr: Digest,
+}
+
 fn valid_string(value: &str) -> bool {
     !value.contains('\0')
 }
@@ -228,6 +267,72 @@ impl TaskOutput {
             TaskOutputStream::Stdout | TaskOutputStream::Stderr
         ) && valid_string(&self.line)
     }
+}
+
+impl RustcAction {
+    pub fn validate(&self) -> bool {
+        let mut input_paths = HashSet::new();
+        self.version == 1
+            && self.kind == "rustc"
+            && self.adapter_version > 0
+            && self.compiler.validate()
+            && valid_strings(&self.arguments)
+            && self.environment.iter().all(|(key, value)| {
+                !key.is_empty() && valid_string(key) && value.as_deref().is_none_or(valid_string)
+            })
+            && !self.inputs.is_empty()
+            && self
+                .inputs
+                .iter()
+                .all(|input| input.validate() && input_paths.insert(&input.path))
+    }
+}
+
+impl RustcCompiler {
+    fn validate(&self) -> bool {
+        [&self.toolchain, &self.rustc_version, &self.host]
+            .into_iter()
+            .all(|value| !value.is_empty() && valid_string(value))
+    }
+}
+
+impl RustcInput {
+    fn validate(&self) -> bool {
+        valid_normalized_path(&self.path) && self.digest.validate()
+    }
+}
+
+impl RustcMetadata {
+    pub fn validate(&self) -> bool {
+        self.version == 1
+            && self.kind == "rustc"
+            && self.stdout.validate()
+            && self.stderr.validate()
+    }
+}
+
+fn valid_normalized_path(path: &str) -> bool {
+    let Some((placeholder, suffix)) = path
+        .strip_prefix("${")
+        .and_then(|path| path.split_once('}'))
+    else {
+        return false;
+    };
+    if placeholder.is_empty()
+        || !placeholder
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'_')
+    {
+        return false;
+    }
+    suffix.is_empty()
+        || suffix.strip_prefix('/').is_some_and(|suffix| {
+            !suffix.is_empty()
+                && !suffix.contains(['\\', '\0'])
+                && suffix
+                    .split('/')
+                    .all(|component| !component.is_empty() && component != "." && component != "..")
+        })
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/server.rs
+++ b/src/server.rs
@@ -979,8 +979,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn publishes_rustc_results_with_artifacts_and_diagnostics() {
+    async fn publishes_rustc_results_without_uploading_source_inputs() {
         let (app, _directory) = test_app().await;
+        // Action input digests identify local source content; only result
+        // metadata, diagnostics, and output artifacts are CAS references.
         let source = digest(b"pub fn widget() {}\n");
         let action = upload_blob(&app, &rustc_action(&source, 1)).await;
         let stdout = upload_blob(&app, b"").await;

--- a/src/server.rs
+++ b/src/server.rs
@@ -23,7 +23,10 @@ use tower_http::{limit::RequestBodyLimitLayer, trace::TraceLayer};
 use crate::{
     auth::{Access, Authorizer},
     metadata::{CommitOutcome, MetadataStore},
-    model::{ActionResult, Algorithm, Digest, Directory, TaskAction, TaskMetadata},
+    model::{
+        ActionResult, Algorithm, Digest, Directory, RustcAction, RustcMetadata, TaskAction,
+        TaskMetadata,
+    },
     storage::{BlobStore, PutOutcome},
 };
 
@@ -82,7 +85,10 @@ async fn capabilities(State(state): State<AppState>) -> impl IntoResponse {
         "protocol":{"major":1,"minor":0},
         "digest_algorithms":["blake3","sha256"],
         "compressors":["identity"],
-        "action_kinds":{"task":{"action_schema":1,"metadata_schema":1}},
+        "action_kinds":{
+            "rustc":{"action_schema":1,"metadata_schema":1},
+            "task":{"action_schema":1,"metadata_schema":1}
+        },
         "features":{"batch":true,"resumable_uploads":false,"delegated_transfers":false},
         "limits":{"max_batch_items":10000,"max_inline_blob_bytes":1048576,"max_blob_bytes":state.max_blob_bytes}
     }))
@@ -264,6 +270,7 @@ async fn put_action_result(
         ));
     }
     let action_kind = validate_action_descriptor(&state, &namespace, &action).await?;
+    validate_action_result_shape(&result, action_kind)?;
     if let Some(metadata) = &result.metadata {
         validate_client_metadata(&state, &namespace, metadata, action_kind).await?;
     }
@@ -366,7 +373,22 @@ async fn validate_tree(state: &AppState, namespace: &str, root: &Digest) -> Resu
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum ActionKind {
+    Rustc,
     Task,
+}
+
+fn validate_action_result_shape(
+    result: &ActionResult,
+    action_kind: ActionKind,
+) -> Result<(), ApiError> {
+    if action_kind == ActionKind::Rustc
+        && (result.metadata.is_none() || result.output_root.is_none())
+    {
+        return Err(ApiError::unprocessable(
+            "rustc action results require metadata and an output root",
+        ));
+    }
+    Ok(())
 }
 
 async fn validate_action_descriptor(
@@ -381,21 +403,30 @@ async fn validate_action_descriptor(
     let kind = object
         .get("kind")
         .and_then(serde_json::Value::as_str)
-        .ok_or_else(|| ApiError::unprocessable("action descriptor kind is required"))?;
+        .ok_or_else(|| ApiError::unprocessable("action descriptor kind is required"))?
+        .to_owned();
     let version = object
         .get("version")
         .and_then(serde_json::Value::as_u64)
         .ok_or_else(|| ApiError::unprocessable("action descriptor version is required"))?;
-    if kind != "task" {
-        return Err(ApiError::unprocessable(format!(
+    match kind.as_str() {
+        "task" => validate_task_action(value, version),
+        "rustc" => validate_rustc_action(value, version),
+        _ => Err(ApiError::unprocessable(format!(
             "unsupported action kind {kind:?}"
-        )));
+        ))),
     }
+}
+
+fn validate_task_action(value: serde_json::Value, version: u64) -> Result<ActionKind, ApiError> {
     if version != 1 {
         return Err(ApiError::unprocessable(format!(
             "unsupported task action schema {version}"
         )));
     }
+    let object = value
+        .as_object()
+        .expect("action descriptors are checked to be objects");
     for field in [
         "version",
         "kind",
@@ -427,6 +458,20 @@ async fn validate_action_descriptor(
     Ok(ActionKind::Task)
 }
 
+fn validate_rustc_action(value: serde_json::Value, version: u64) -> Result<ActionKind, ApiError> {
+    if version != 1 {
+        return Err(ApiError::unprocessable(format!(
+            "unsupported rustc action schema {version}"
+        )));
+    }
+    let action = serde_json::from_value::<RustcAction>(value)
+        .map_err(|error| ApiError::unprocessable(format!("invalid rustc action: {error}")))?;
+    if !action.validate() {
+        return Err(ApiError::unprocessable("invalid rustc action values"));
+    }
+    Ok(ActionKind::Rustc)
+}
+
 async fn validate_client_metadata(
     state: &AppState,
     namespace: &str,
@@ -445,11 +490,22 @@ async fn validate_client_metadata(
         .get("version")
         .and_then(serde_json::Value::as_u64)
         .ok_or_else(|| ApiError::unprocessable("client metadata version is required"))?;
-    if kind != "task" || action_kind != ActionKind::Task {
+    let expected_kind = match action_kind {
+        ActionKind::Rustc => "rustc",
+        ActionKind::Task => "task",
+    };
+    if kind != expected_kind {
         return Err(ApiError::unprocessable(
             "client metadata kind does not match action kind",
         ));
     }
+    match action_kind {
+        ActionKind::Task => validate_task_metadata(value, version),
+        ActionKind::Rustc => validate_rustc_metadata(state, namespace, value, version).await,
+    }
+}
+
+fn validate_task_metadata(value: serde_json::Value, version: u64) -> Result<(), ApiError> {
     if version != 1 {
         return Err(ApiError::unprocessable(format!(
             "unsupported task metadata schema {version}"
@@ -463,6 +519,27 @@ async fn validate_client_metadata(
     for root in metadata.roots {
         validate_task_root(&root)?;
     }
+    Ok(())
+}
+
+async fn validate_rustc_metadata(
+    state: &AppState,
+    namespace: &str,
+    value: serde_json::Value,
+    version: u64,
+) -> Result<(), ApiError> {
+    if version != 1 {
+        return Err(ApiError::unprocessable(format!(
+            "unsupported rustc metadata schema {version}"
+        )));
+    }
+    let metadata: RustcMetadata = serde_json::from_value(value)
+        .map_err(|error| ApiError::unprocessable(format!("invalid rustc metadata: {error}")))?;
+    if !metadata.validate() {
+        return Err(ApiError::unprocessable("invalid rustc metadata values"));
+    }
+    require_blob(state, namespace, &metadata.stdout, "rustc stdout blob").await?;
+    require_blob(state, namespace, &metadata.stderr, "rustc stderr blob").await?;
     Ok(())
 }
 
@@ -757,6 +834,50 @@ mod tests {
         }))
     }
 
+    fn rustc_action(input: &Digest, version: u8) -> Vec<u8> {
+        canonical(serde_json::json!({
+            "adapter_version":1,
+            "arguments":[
+                "--crate-name=widget",
+                "--crate-type=lib",
+                "--emit=metadata,link",
+                "--out-dir=${target}/debug/deps"
+            ],
+            "compiler":{
+                "host":"x86_64-unknown-linux-gnu",
+                "rustc_version":"1.97.1 (test)",
+                "toolchain":"core:rust@1.97.1"
+            },
+            "environment":{"CARGO_PKG_VERSION":"1.0.0"},
+            "inputs":[{"digest":input,"path":"${workspace}/src/lib.rs"}],
+            "kind":"rustc",
+            "version":version
+        }))
+    }
+
+    fn rustc_metadata(stdout: &Digest, stderr: &Digest, version: u8) -> Vec<u8> {
+        canonical(serde_json::json!({
+            "kind":"rustc",
+            "stderr":stderr,
+            "stdout":stdout,
+            "version":version
+        }))
+    }
+
+    fn output_directory(artifact: &Digest) -> Vec<u8> {
+        canonical(serde_json::json!({
+            "directories":[],
+            "files":[{
+                "digest":artifact,
+                "executable":false,
+                "mode":420,
+                "name":"libwidget.rlib"
+            }],
+            "symlinks":[],
+            "version":1
+        }))
+    }
+
     async fn upload_blob(app: &Router, bytes: &[u8]) -> Digest {
         let digest = digest(bytes);
         let uri = format!(
@@ -840,7 +961,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn advertises_task_action_schemas() {
+    async fn advertises_action_schemas() {
         let (app, _directory) = test_app().await;
         let response = app
             .oneshot(request("GET", "/v1/capabilities".into(), Body::empty()))
@@ -852,7 +973,205 @@ mod tests {
                 .unwrap();
         assert_eq!(body["action_kinds"]["task"]["action_schema"], 1);
         assert_eq!(body["action_kinds"]["task"]["metadata_schema"], 1);
+        assert_eq!(body["action_kinds"]["rustc"]["action_schema"], 1);
+        assert_eq!(body["action_kinds"]["rustc"]["metadata_schema"], 1);
         assert!(body["features"].get("signed_results").is_none());
+    }
+
+    #[tokio::test]
+    async fn publishes_rustc_results_with_artifacts_and_diagnostics() {
+        let (app, _directory) = test_app().await;
+        let source = digest(b"pub fn widget() {}\n");
+        let action = upload_blob(&app, &rustc_action(&source, 1)).await;
+        let stdout = upload_blob(&app, b"").await;
+        let stderr = upload_blob(&app, b"warning: cached diagnostic\n").await;
+        let metadata = upload_blob(&app, &rustc_metadata(&stdout, &stderr, 1)).await;
+        let artifact = upload_blob(&app, b"rlib artifact").await;
+        let output_root = upload_blob(&app, &output_directory(&artifact)).await;
+        let result_uri = format!(
+            "/v1/action-results/{}/{}/{}",
+            action.algorithm, action.hash, action.size
+        );
+        let body = serde_json::to_vec(&ActionResult {
+            action,
+            metadata: Some(metadata),
+            output_root: Some(output_root),
+            version: 1,
+        })
+        .unwrap();
+
+        assert_eq!(
+            app.oneshot(request("PUT", result_uri, Body::from(body)))
+                .await
+                .unwrap()
+                .status(),
+            StatusCode::CREATED
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_incomplete_rustc_results() {
+        let (app, _directory) = test_app().await;
+        let source = digest(b"pub fn widget() {}\n");
+        let action = upload_blob(&app, &rustc_action(&source, 1)).await;
+        let result_uri = format!(
+            "/v1/action-results/{}/{}/{}",
+            action.algorithm, action.hash, action.size
+        );
+        let body = serde_json::to_vec(&ActionResult {
+            action,
+            metadata: None,
+            output_root: None,
+            version: 1,
+        })
+        .unwrap();
+
+        assert_eq!(
+            app.oneshot(request("PUT", result_uri, Body::from(body)))
+                .await
+                .unwrap()
+                .status(),
+            StatusCode::UNPROCESSABLE_ENTITY
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_missing_rustc_diagnostic_blobs() {
+        let (app, _directory) = test_app().await;
+        let source = digest(b"pub fn widget() {}\n");
+        let action = upload_blob(&app, &rustc_action(&source, 1)).await;
+        let stdout = upload_blob(&app, b"").await;
+        let missing_stderr = digest(b"missing diagnostic\n");
+        let metadata = upload_blob(&app, &rustc_metadata(&stdout, &missing_stderr, 1)).await;
+        let artifact = upload_blob(&app, b"rlib artifact").await;
+        let output_root = upload_blob(&app, &output_directory(&artifact)).await;
+        let result_uri = format!(
+            "/v1/action-results/{}/{}/{}",
+            action.algorithm, action.hash, action.size
+        );
+        let body = serde_json::to_vec(&ActionResult {
+            action,
+            metadata: Some(metadata),
+            output_root: Some(output_root),
+            version: 1,
+        })
+        .unwrap();
+
+        assert_eq!(
+            app.oneshot(request("PUT", result_uri, Body::from(body)))
+                .await
+                .unwrap()
+                .status(),
+            StatusCode::UNPROCESSABLE_ENTITY
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_invalid_rustc_action_inputs() {
+        let (app, _directory) = test_app().await;
+        let source = digest(b"pub fn widget() {}\n");
+        let mut action: serde_json::Value =
+            serde_json::from_slice(&rustc_action(&source, 1)).unwrap();
+        action["inputs"][0]["path"] = "../src/lib.rs".into();
+        let action = upload_blob(&app, &canonical(action)).await;
+        let result_uri = format!(
+            "/v1/action-results/{}/{}/{}",
+            action.algorithm, action.hash, action.size
+        );
+        let body = serde_json::to_vec(&ActionResult {
+            action,
+            metadata: None,
+            output_root: None,
+            version: 1,
+        })
+        .unwrap();
+
+        let response = app
+            .oneshot(request("PUT", result_uri, Body::from(body)))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        let body: serde_json::Value =
+            serde_json::from_slice(&response.into_body().collect().await.unwrap().to_bytes())
+                .unwrap();
+        assert_eq!(body["error"], "invalid rustc action values");
+    }
+
+    #[tokio::test]
+    async fn rejects_unknown_rustc_action_fields() {
+        let (app, _directory) = test_app().await;
+        let source = digest(b"pub fn widget() {}\n");
+        let mut action: serde_json::Value =
+            serde_json::from_slice(&rustc_action(&source, 1)).unwrap();
+        action["unknown"] = true.into();
+        let action = upload_blob(&app, &canonical(action)).await;
+        let result_uri = format!(
+            "/v1/action-results/{}/{}/{}",
+            action.algorithm, action.hash, action.size
+        );
+        let body = serde_json::to_vec(&ActionResult {
+            action,
+            metadata: None,
+            output_root: None,
+            version: 1,
+        })
+        .unwrap();
+
+        let response = app
+            .oneshot(request("PUT", result_uri, Body::from(body)))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        let body: serde_json::Value =
+            serde_json::from_slice(&response.into_body().collect().await.unwrap().to_bytes())
+                .unwrap();
+        assert!(
+            body["error"]
+                .as_str()
+                .unwrap()
+                .starts_with("invalid rustc action:")
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_unknown_rustc_metadata_fields() {
+        let (app, _directory) = test_app().await;
+        let source = digest(b"pub fn widget() {}\n");
+        let action = upload_blob(&app, &rustc_action(&source, 1)).await;
+        let stdout = upload_blob(&app, b"").await;
+        let stderr = upload_blob(&app, b"warning\n").await;
+        let mut metadata: serde_json::Value =
+            serde_json::from_slice(&rustc_metadata(&stdout, &stderr, 1)).unwrap();
+        metadata["unknown"] = true.into();
+        let metadata = upload_blob(&app, &canonical(metadata)).await;
+        let artifact = upload_blob(&app, b"rlib artifact").await;
+        let output_root = upload_blob(&app, &output_directory(&artifact)).await;
+        let result_uri = format!(
+            "/v1/action-results/{}/{}/{}",
+            action.algorithm, action.hash, action.size
+        );
+        let body = serde_json::to_vec(&ActionResult {
+            action,
+            metadata: Some(metadata),
+            output_root: Some(output_root),
+            version: 1,
+        })
+        .unwrap();
+
+        let response = app
+            .oneshot(request("PUT", result_uri, Body::from(body)))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        let body: serde_json::Value =
+            serde_json::from_slice(&response.into_body().collect().await.unwrap().to_bytes())
+                .unwrap();
+        assert!(
+            body["error"]
+                .as_str()
+                .unwrap()
+                .starts_with("invalid rustc metadata:")
+        );
     }
 
     #[tokio::test]
@@ -883,7 +1202,7 @@ mod tests {
     async fn rejects_metadata_kind_mismatch() {
         let (app, _directory) = test_app().await;
         let action = upload_blob(&app, &task_action(1)).await;
-        let metadata = upload_blob(&app, &task_metadata("rust", 1)).await;
+        let metadata = upload_blob(&app, &task_metadata("rustc", 1)).await;
         let result_uri = format!(
             "/v1/action-results/{}/{}/{}",
             action.algorithm, action.hash, action.size


### PR DESCRIPTION
## Summary
- advertise the rustc action and metadata schemas in cache capabilities
- validate canonical rustc action descriptors, diagnostic metadata, and output roots
- distinguish local input digests from remotely stored CAS references

## Tests
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the action-result commit validation path for a new action kind; behavior is additive and mirrors existing task validation, with no auth or storage API changes.
> 
> **Overview**
> Adds **rustc** as a first-class action kind alongside **task**, advertised in `/v1/capabilities` with action and metadata schema version 1.
> 
> **Action descriptors** deserialize and validate `RustcAction` (compiler identity, argv, env, and inputs with `${placeholder}` paths). Input digests are for cache keys only—source inputs are not required as uploaded blobs.
> 
> **Publishing rustc results** now requires both client metadata and an output directory tree. Metadata must be kind `rustc` and reference **stdout** and **stderr** blobs that already exist in the namespace; the output tree is validated like task results. Incomplete results, bad input paths, unknown JSON fields, and missing diagnostic blobs are rejected with `422`.
> 
> README clarifies that publish-time verification walks metadata and output trees, and that descriptor input digests are local, not CAS references.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8059e058ac023c29319723a1e4824dfd3da481c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Rust compiler actions and metadata.
  * Rust compiler capabilities are now advertised and validated.
  * Compiler results require output metadata and replayable stdout/stderr diagnostics.
  * Added validation for compiler versions, inputs, environment values, and normalized paths.

* **Documentation**
  * Updated API documentation with Rust compiler schema support and blob validation requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->