### PR TITLE
feat(protocol): add mutable action manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,9 +162,12 @@ All cache requests send `Mise-Cache-Namespace` and, unless anonymous access is e
 - `GET|PUT /v1/blobs/{algorithm}/{hash}/{size}`
 - `POST /v1/blobs:missing`
 - `GET|PUT /v1/action-results/{algorithm}/{hash}/{size}`
+- `GET|PUT /v1/action-manifests/{algorithm}/{hash}/{size}`
 - `GET /metrics`
 
 Blobs and action results are immutable. Repeating an identical write is idempotent; attempting to replace an existing action result returns `409 Conflict`. The server verifies uploaded content and every blob reachable from result metadata and output trees before publishing an action result. Content digests inside an action descriptor identify local inputs for key construction; they are not CAS references, and clients do not upload source inputs.
+
+Task action manifests are mutable discovery indexes for fresh workers. Their stable key is the BLAKE3 digest of the canonical task-manifest selector. Writes use optimistic concurrency: create with `If-None-Match: *`, or update the ETag returned by `GET` with `If-Match`. A stale update returns `412 Precondition Failed`, so clients must read, merge, and retry without dropping actions learned by another worker.
 
 `GET /v1/capabilities` advertises the action kinds and exact schema versions accepted by the server. Action-result keys use BLAKE3. Version 1 accepts task and rustc action and metadata schema version 1. Rustc results require an output directory tree plus metadata referencing raw stdout and stderr blobs so clients can replay compiler diagnostics byte-for-byte.
 

--- a/migrations/0002_action_manifests.sql
+++ b/migrations/0002_action_manifests.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS action_manifests (
+    namespace TEXT NOT NULL,
+    algorithm TEXT NOT NULL CHECK (algorithm = 'blake3'),
+    hash TEXT NOT NULL,
+    size BIGINT NOT NULL CHECK (size >= 0),
+    etag TEXT NOT NULL,
+    manifest JSONB NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (namespace, algorithm, hash, size)
+);

--- a/src/metadata/memory.rs
+++ b/src/metadata/memory.rs
@@ -4,13 +4,14 @@ use std::{
     sync::RwLock,
 };
 
-use super::{CommitOutcome, MetadataStore};
-use crate::model::{ActionResult, Digest};
+use super::{CommitOutcome, ManifestCommitOutcome, ManifestRecord, MetadataStore};
+use crate::model::{ActionResult, Digest, TaskActionManifest};
 
 #[derive(Default)]
 pub struct MemoryMetadata {
     entries: RwLock<HashMap<(String, Digest), Vec<u8>>>,
     blobs: RwLock<HashSet<(String, Digest)>>,
+    manifests: RwLock<HashMap<(String, Digest), (String, TaskActionManifest)>>,
 }
 
 #[async_trait]
@@ -55,5 +56,51 @@ impl MetadataStore for MemoryMetadata {
             Some(existing) if *existing == encoded => Ok(CommitOutcome::AlreadyExists),
             Some(_) => Ok(CommitOutcome::Conflict),
         }
+    }
+
+    async fn get_manifest(
+        &self,
+        namespace: &str,
+        key: &Digest,
+    ) -> anyhow::Result<Option<ManifestRecord>> {
+        Ok(self
+            .manifests
+            .read()
+            .expect("metadata lock poisoned")
+            .get(&(namespace.to_owned(), key.clone()))
+            .map(|(etag, manifest)| ManifestRecord {
+                etag: etag.clone(),
+                manifest: manifest.clone(),
+            }))
+    }
+
+    async fn commit_manifest(
+        &self,
+        namespace: &str,
+        key: &Digest,
+        expected_etag: Option<&str>,
+        etag: &str,
+        manifest: &TaskActionManifest,
+    ) -> anyhow::Result<ManifestCommitOutcome> {
+        let mut manifests = self.manifests.write().expect("metadata lock poisoned");
+        let entry = manifests.get(&(namespace.to_owned(), key.clone()));
+        let matches = match (entry, expected_etag) {
+            (None, None) => true,
+            (Some((current, _)), Some(expected)) => current == expected,
+            _ => false,
+        };
+        if !matches {
+            return Ok(ManifestCommitOutcome::PreconditionFailed);
+        }
+        let outcome = if entry.is_some() {
+            ManifestCommitOutcome::Updated
+        } else {
+            ManifestCommitOutcome::Created
+        };
+        manifests.insert(
+            (namespace.to_owned(), key.clone()),
+            (etag.to_owned(), manifest.clone()),
+        );
+        Ok(outcome)
     }
 }

--- a/src/metadata/mod.rs
+++ b/src/metadata/mod.rs
@@ -1,7 +1,7 @@
 mod memory;
 mod postgres;
 
-use crate::model::{ActionResult, Digest};
+use crate::model::{ActionResult, Digest, TaskActionManifest};
 use async_trait::async_trait;
 
 pub use memory::MemoryMetadata;
@@ -12,6 +12,18 @@ pub enum CommitOutcome {
     Created,
     AlreadyExists,
     Conflict,
+}
+
+pub struct ManifestRecord {
+    pub etag: String,
+    pub manifest: TaskActionManifest,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ManifestCommitOutcome {
+    Created,
+    Updated,
+    PreconditionFailed,
 }
 
 #[async_trait]
@@ -25,6 +37,19 @@ pub trait MetadataStore: Send + Sync {
         action: &Digest,
         result: &ActionResult,
     ) -> anyhow::Result<CommitOutcome>;
+    async fn get_manifest(
+        &self,
+        namespace: &str,
+        key: &Digest,
+    ) -> anyhow::Result<Option<ManifestRecord>>;
+    async fn commit_manifest(
+        &self,
+        namespace: &str,
+        key: &Digest,
+        expected_etag: Option<&str>,
+        etag: &str,
+        manifest: &TaskActionManifest,
+    ) -> anyhow::Result<ManifestCommitOutcome>;
 }
 
 pub async fn from_url(url: &str) -> anyhow::Result<std::sync::Arc<dyn MetadataStore>> {

--- a/src/metadata/postgres.rs
+++ b/src/metadata/postgres.rs
@@ -1,8 +1,8 @@
 use async_trait::async_trait;
 use sqlx::{PgPool, Row};
 
-use super::{CommitOutcome, MetadataStore};
-use crate::model::{ActionResult, Digest};
+use super::{CommitOutcome, ManifestCommitOutcome, ManifestRecord, MetadataStore};
+use crate::model::{ActionResult, Digest, TaskActionManifest};
 
 pub struct PostgresMetadata {
     pool: PgPool,
@@ -61,5 +61,51 @@ impl MetadataStore for PostgresMetadata {
         } else {
             Ok(CommitOutcome::Conflict)
         }
+    }
+
+    async fn get_manifest(
+        &self,
+        namespace: &str,
+        key: &Digest,
+    ) -> anyhow::Result<Option<ManifestRecord>> {
+        let row = sqlx::query("SELECT etag, manifest FROM action_manifests WHERE namespace = $1 AND algorithm = $2 AND hash = $3 AND size = $4")
+            .bind(namespace).bind(key.algorithm.to_string()).bind(&key.hash).bind(key.size as i64)
+            .fetch_optional(&self.pool).await?;
+        row.map(|row| {
+            Ok(ManifestRecord {
+                etag: row.get("etag"),
+                manifest: serde_json::from_value(row.get("manifest"))?,
+            })
+        })
+        .transpose()
+    }
+
+    async fn commit_manifest(
+        &self,
+        namespace: &str,
+        key: &Digest,
+        expected_etag: Option<&str>,
+        etag: &str,
+        manifest: &TaskActionManifest,
+    ) -> anyhow::Result<ManifestCommitOutcome> {
+        let manifest = serde_json::to_value(manifest)?;
+        let rows = if let Some(expected_etag) = expected_etag {
+            sqlx::query("UPDATE action_manifests SET etag = $5, manifest = $6, updated_at = now() WHERE namespace = $1 AND algorithm = $2 AND hash = $3 AND size = $4 AND etag = $7")
+                .bind(namespace).bind(key.algorithm.to_string()).bind(&key.hash).bind(key.size as i64)
+                .bind(etag).bind(&manifest).bind(expected_etag)
+                .execute(&self.pool).await?.rows_affected()
+        } else {
+            sqlx::query("INSERT INTO action_manifests (namespace, algorithm, hash, size, etag, manifest) VALUES ($1, $2, $3, $4, $5, $6) ON CONFLICT DO NOTHING")
+                .bind(namespace).bind(key.algorithm.to_string()).bind(&key.hash).bind(key.size as i64)
+                .bind(etag).bind(&manifest)
+                .execute(&self.pool).await?.rows_affected()
+        };
+        Ok(if rows == 0 {
+            ManifestCommitOutcome::PreconditionFailed
+        } else if expected_etag.is_some() {
+            ManifestCommitOutcome::Updated
+        } else {
+            ManifestCommitOutcome::Created
+        })
     }
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -53,6 +53,79 @@ impl Digest {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TaskActionManifest {
+    pub predictions: Vec<TaskActionPrediction>,
+    pub task: String,
+    pub version: u8,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TaskActionPrediction {
+    pub action: Digest,
+    pub adapter: String,
+    pub invocation: Digest,
+    pub payload: String,
+}
+
+#[derive(Serialize)]
+struct TaskActionManifestSelector<'a> {
+    kind: &'static str,
+    task: &'a str,
+    version: u8,
+}
+
+impl TaskActionManifest {
+    pub fn validate(&self) -> bool {
+        let mut invocations = HashSet::new();
+        self.version == 1
+            && valid_task_identity(&self.task)
+            && self.predictions.len() <= 16 * 1024
+            && self.predictions.iter().all(|prediction| {
+                prediction.validate() && invocations.insert(&prediction.invocation)
+            })
+    }
+
+    pub fn selector_digest(&self) -> Digest {
+        let selector = serde_json::to_vec(&TaskActionManifestSelector {
+            kind: "task_action_manifest",
+            task: &self.task,
+            version: 1,
+        })
+        .expect("manifest selector must serialize");
+        Digest {
+            algorithm: Algorithm::Blake3,
+            hash: blake3::hash(&selector).to_hex().to_string(),
+            size: selector.len() as u64,
+        }
+    }
+}
+
+impl TaskActionPrediction {
+    fn validate(&self) -> bool {
+        self.action.algorithm == Algorithm::Blake3
+            && self.action.validate()
+            && self.invocation.algorithm == Algorithm::Blake3
+            && self.invocation.validate()
+            && !self.adapter.is_empty()
+            && self
+                .adapter
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+            && self.payload.len() <= 256 * 1024
+            && serde_json::from_str::<serde_json::Value>(&self.payload).is_ok()
+    }
+}
+
+fn valid_task_identity(value: &str) -> bool {
+    value.len() == 64
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct ActionResult {

--- a/src/server.rs
+++ b/src/server.rs
@@ -22,10 +22,10 @@ use tower_http::{limit::RequestBodyLimitLayer, trace::TraceLayer};
 
 use crate::{
     auth::{Access, Authorizer},
-    metadata::{CommitOutcome, MetadataStore},
+    metadata::{CommitOutcome, ManifestCommitOutcome, MetadataStore},
     model::{
         ActionResult, Algorithm, Digest, Directory, RustcAction, RustcMetadata, TaskAction,
-        TaskMetadata,
+        TaskActionManifest, TaskMetadata,
     },
     storage::{BlobStore, PutOutcome},
 };
@@ -70,6 +70,10 @@ pub fn router(state: AppState) -> Router {
             "/v1/action-results/{algorithm}/{hash}/{size}",
             get(get_action_result).put(put_action_result),
         )
+        .route(
+            "/v1/action-manifests/{algorithm}/{hash}/{size}",
+            get(get_action_manifest).put(put_action_manifest),
+        )
         .route("/metrics", get(metrics))
         .layer(RequestBodyLimitLayer::new(limit))
         .layer(TraceLayer::new_for_http())
@@ -89,7 +93,7 @@ async fn capabilities(State(state): State<AppState>) -> impl IntoResponse {
             "rustc":{"action_schema":1,"metadata_schema":1},
             "task":{"action_schema":1,"metadata_schema":1}
         },
-        "features":{"batch":true,"resumable_uploads":false,"delegated_transfers":false},
+        "features":{"action_manifests":true,"batch":true,"resumable_uploads":false,"delegated_transfers":false},
         "limits":{"max_batch_items":10000,"max_inline_blob_bytes":1048576,"max_blob_bytes":state.max_blob_bytes}
     }))
 }
@@ -290,6 +294,68 @@ async fn put_action_result(
             "an immutable action result already exists",
         )),
     }
+}
+
+async fn get_action_manifest(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(parts): Path<(String, String, u64)>,
+) -> Result<Response, ApiError> {
+    let namespace = state.auth.authorize(&headers, Access::Read).await?;
+    let key = parse_action_digest(parts)?;
+    let record = state
+        .metadata
+        .get_manifest(&namespace, &key)
+        .await
+        .map_err(ApiError::internal)?
+        .ok_or_else(|| ApiError::not_found("action manifest not found"))?;
+    let body = serde_json::to_vec(&record.manifest).map_err(ApiError::internal)?;
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(
+            header::CONTENT_TYPE,
+            "application/vnd.mise.cache-task-action-manifest.v1+json",
+        )
+        .header(header::ETAG, quoted_etag(&record.etag))
+        .body(Body::from(body))
+        .map_err(ApiError::internal)
+}
+
+async fn put_action_manifest(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(parts): Path<(String, String, u64)>,
+    Json(manifest): Json<TaskActionManifest>,
+) -> Result<Response, ApiError> {
+    let namespace = state.auth.authorize(&headers, Access::Write).await?;
+    let key = parse_action_digest(parts)?;
+    if !manifest.validate() || manifest.selector_digest() != key {
+        return Err(ApiError::bad_request(
+            "action manifest does not match request",
+        ));
+    }
+    let expected_etag = manifest_precondition(&headers)?;
+    let bytes = serde_json::to_vec(&manifest).map_err(ApiError::internal)?;
+    let etag = blake3::hash(&bytes).to_hex().to_string();
+    let outcome = state
+        .metadata
+        .commit_manifest(&namespace, &key, expected_etag.as_deref(), &etag, &manifest)
+        .await
+        .map_err(ApiError::internal)?;
+    let status = match outcome {
+        ManifestCommitOutcome::Created => StatusCode::CREATED,
+        ManifestCommitOutcome::Updated => StatusCode::NO_CONTENT,
+        ManifestCommitOutcome::PreconditionFailed => {
+            return Err(ApiError::precondition(
+                "action manifest changed; read and merge it before retrying",
+            ));
+        }
+    };
+    Response::builder()
+        .status(status)
+        .header(header::ETAG, quoted_etag(&etag))
+        .body(Body::empty())
+        .map_err(ApiError::internal)
 }
 
 async fn require_blob(
@@ -685,6 +751,37 @@ fn require_immutable_precondition(headers: &HeaderMap) -> Result<(), ApiError> {
     }
 }
 
+fn manifest_precondition(headers: &HeaderMap) -> Result<Option<String>, ApiError> {
+    if headers
+        .get(header::IF_NONE_MATCH)
+        .and_then(|value| value.to_str().ok())
+        == Some("*")
+    {
+        return Ok(None);
+    }
+    let value = headers
+        .get(header::IF_MATCH)
+        .and_then(|value| value.to_str().ok())
+        .ok_or_else(|| {
+            ApiError::precondition_required("If-None-Match: * or If-Match is required")
+        })?;
+    let etag = value
+        .strip_prefix('"')
+        .and_then(|value| value.strip_suffix('"'))
+        .filter(|value| {
+            value.len() == 64
+                && value
+                    .bytes()
+                    .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+        })
+        .ok_or_else(|| ApiError::bad_request("If-Match must contain one strong BLAKE3 ETag"))?;
+    Ok(Some(etag.to_owned()))
+}
+
+fn quoted_etag(etag: &str) -> String {
+    format!("\"{etag}\"")
+}
+
 #[derive(Default)]
 struct Metrics {
     blob_hits: AtomicU64,
@@ -731,6 +828,9 @@ impl ApiError {
     }
     pub fn precondition(message: impl ToString) -> Self {
         Self::new(StatusCode::PRECONDITION_FAILED, message)
+    }
+    pub fn precondition_required(message: impl ToString) -> Self {
+        Self::new(StatusCode::PRECONDITION_REQUIRED, message)
     }
     pub fn upgrade_required() -> Self {
         Self {
@@ -878,6 +978,23 @@ mod tests {
         }))
     }
 
+    fn action_manifest(task: &str, actions: &[&[u8]]) -> TaskActionManifest {
+        TaskActionManifest {
+            predictions: actions
+                .iter()
+                .enumerate()
+                .map(|(index, action)| crate::model::TaskActionPrediction {
+                    action: digest(action),
+                    adapter: "rustc".into(),
+                    invocation: digest(format!("invocation-{index}").as_bytes()),
+                    payload: "{}".into(),
+                })
+                .collect(),
+            task: task.into(),
+            version: 1,
+        }
+    }
+
     async fn upload_blob(app: &Router, bytes: &[u8]) -> Digest {
         let digest = digest(bytes);
         let uri = format!(
@@ -976,6 +1093,71 @@ mod tests {
         assert_eq!(body["action_kinds"]["rustc"]["action_schema"], 1);
         assert_eq!(body["action_kinds"]["rustc"]["metadata_schema"], 1);
         assert!(body["features"].get("signed_results").is_none());
+    }
+
+    #[tokio::test]
+    async fn action_manifests_use_optimistic_concurrency() {
+        let (app, _directory) = test_app().await;
+        let task = "a".repeat(64);
+        let first = action_manifest(&task, &[b"first action"]);
+        let key = first.selector_digest();
+        let uri = format!(
+            "/v1/action-manifests/{}/{}/{}",
+            key.algorithm, key.hash, key.size
+        );
+        let response = app
+            .clone()
+            .oneshot(request(
+                "PUT",
+                uri.clone(),
+                Body::from(serde_json::to_vec(&first).unwrap()),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::CREATED);
+        let first_etag = response.headers()[header::ETAG].clone();
+
+        let response = app
+            .clone()
+            .oneshot(request("GET", uri.clone(), Body::empty()))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response.headers()[header::ETAG], first_etag);
+
+        let second = action_manifest(&task, &[b"first action", b"second action"]);
+        let mut update = request(
+            "PUT",
+            uri.clone(),
+            Body::from(serde_json::to_vec(&second).unwrap()),
+        );
+        update.headers_mut().remove(header::IF_NONE_MATCH);
+        update
+            .headers_mut()
+            .insert(header::IF_MATCH, first_etag.clone());
+        let response = app.clone().oneshot(update).await.unwrap();
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
+
+        let mut stale = request(
+            "PUT",
+            uri.clone(),
+            Body::from(serde_json::to_vec(&first).unwrap()),
+        );
+        stale.headers_mut().remove(header::IF_NONE_MATCH);
+        stale.headers_mut().insert(header::IF_MATCH, first_etag);
+        assert_eq!(
+            app.clone().oneshot(stale).await.unwrap().status(),
+            StatusCode::PRECONDITION_FAILED
+        );
+
+        let response = app
+            .oneshot(request("GET", uri, Body::empty()))
+            .await
+            .unwrap();
+        let stored: TaskActionManifest =
+            serde_json::from_slice(&response.into_body().collect().await.unwrap().to_bytes())
+                .unwrap();
+        assert_eq!(stored, second);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- add a typed mutable task-action manifest endpoint for fresh build workers
- use strong ETags and conditional writes so concurrent builders merge instead of losing discoveries
- persist manifests in memory and PostgreSQL metadata backends and advertise the capability

## Tests
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New mutable metadata path and optimistic-concurrency contract; incorrect client merge/retry could drop predictions, but immutable blobs and action results are unchanged.
> 
> **Overview**
> Introduces **mutable task action manifests** so workers can publish and merge discovery indexes keyed by the BLAKE3 digest of a canonical task-manifest selector.
> 
> New **`GET|PUT /v1/action-manifests/{algorithm}/{hash}/{size}`** handlers validate `TaskActionManifest` (predictions, task identity, schema rules), store manifests in memory and PostgreSQL (`action_manifests` migration), and return BLAKE3 **ETags** on the manifest JSON. Writes require **`If-None-Match: *`** to create or **`If-Match`** with the current ETag to update; mismatches yield **412** so clients must read-merge-retry. **`/v1/capabilities`** now advertises **`action_manifests: true`**, and the README documents the endpoint and concurrency model.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b92568b7a802eca7a0208d9512f14149cce0916d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->