### PR TITLE
feat(deploy): support existing OVH hosts over Tailscale

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,16 @@ jobs:
       - run: terraform -chdir=deploy/ovh/terraform fmt -check -recursive
       - run: terraform -chdir=deploy/ovh/terraform init -backend=false
       - run: terraform -chdir=deploy/ovh/terraform validate
+      - name: Plan existing-server deployment without provider credentials
+        run: |
+          terraform -chdir=deploy/ovh/terraform plan \
+            -input=false \
+            -lock=false \
+            -refresh=false \
+            -var='domain=cache.mise.jdx.dev' \
+            -var='cloudflare_account_id=0123456789abcdef0123456789abcdef' \
+            -var='r2_bucket=mise-cache-production' \
+            -var='existing_server_ipv4=203.0.113.10'
       - name: Validate bootstrap plan
         run: |
           install -d -m 0700 deploy/ovh/bootstrap/runtime

--- a/deploy/ovh/README.md
+++ b/deploy/ovh/README.md
@@ -1,15 +1,18 @@
 # OVH US deployment
 
 This deployment runs Caddy, mise-cache, and PostgreSQL on one OVHcloud VPS in
-Vint Hill, Virginia. Cache blobs live in a Cloudflare R2 bucket with an Eastern
-North America location hint. The server is disposable; PostgreSQL is small and
-the much larger blob store remains outside the server.
+Vint Hill, Virginia. Cache blobs live in a manually created Cloudflare R2
+bucket. The server is disposable; PostgreSQL is small and the much larger blob
+store remains outside the server.
 
-Terraform provisions:
+Terraform records or provisions the server:
 
-- one monthly OVH US VPS in `US-EAST-VA`;
-- an R2 Standard bucket with the `enam` location hint; and
-- a DNS-only Cloudflare record pointing at the VPS.
+- infrastructure around an existing VPS identified by IPv4 address, or one new
+  monthly OVH US VPS in `US-EAST-VA`.
+
+The R2 bucket and DNS record are deliberately created in Cloudflare by an
+operator. Terraform therefore needs no Cloudflare API token, and mise-cache can
+use an Object Read & Write token scoped to only its bucket.
 
 [`mise bootstrap remote`](https://mise.jdx.dev/bootstrap/remote.html) installs
 and converges the host firewall, fail2ban, automatic security updates, Docker,
@@ -31,11 +34,15 @@ and plan availability before applying the configuration.
 - Terraform or OpenTofu 1.8 or newer
 - mise 2026.8.2 or newer
 - local `curl`, `jq`, `ssh`, and `tar` commands
-- an OVH US account with a default payment method
-- OVH API credentials authorized to order and manage a VPS
-- a current OVH US VPS plan code and Ubuntu image ID
-- a Cloudflare API token with R2 bucket and DNS edit permissions
-- a separate R2 S3 token restricted to the cache bucket
+- an existing Ubuntu VPS with key-based SSH access, or an OVH US account with
+  credentials and a default payment method for ordering a new VPS
+- when `OVH_SSH_HOST` uses a tailnet address, a server already enrolled in the
+  same tailnet with TCP 22 permitted by its tailnet policy, plus a connected
+  local Tailscale client and `tailscale` command; bootstrap permits SSH on the
+  existing `tailscale0` interface but does not install or enroll Tailscale
+- a current OVH US VPS plan code and Ubuntu image ID only when ordering a VPS
+- an existing R2 bucket and Object Read & Write token restricted to that bucket
+- a DNS-only Cloudflare A record for the public cache hostname
 - a published, immutable mise-cache image tag or digest
 
 Set `TERRAFORM_COMMAND=tofu` when using OpenTofu for the deploy step.
@@ -61,15 +68,29 @@ cd deploy/ovh/terraform
 cp terraform.tfvars.example terraform.tfvars
 ```
 
-Export provider credentials, then review and apply the order carefully because
-creating `ovh_vps.cache` purchases a recurring service:
+Set `existing_server_ipv4` to adopt a server that has already been purchased.
+In that mode Terraform does not create or manage the VPS, and the OVH provider
+does not need credentials. Leave it unset and provide `plan_code`, `image_id`,
+and `public_ssh_key` to order a new server.
+
+Do not switch a VPS that this configuration already manages directly into
+adoption mode. The resource has `prevent_destroy` enabled, so Terraform rejects
+the otherwise destructive transition. First record and verify
+`terraform output -raw server_ipv4`, set `existing_server_ipv4` to that exact
+address, remove only `ovh_vps.cache[0]` from state with
+`terraform state rm 'ovh_vps.cache[0]'`, and then review a fresh plan before
+applying. Removing the resource from state does not delete the VPS.
+
+Export OVH provider credentials only when ordering a VPS, then review the plan
+carefully.
+Creating `ovh_vps.cache[0]` purchases a recurring service; an existing-server
+plan must not contain that resource:
 
 ```sh
 export OVH_ENDPOINT=ovh-us
 export OVH_APPLICATION_KEY=...
 export OVH_APPLICATION_SECRET=...
 export OVH_CONSUMER_KEY=...
-export CLOUDFLARE_API_TOKEN=...
 terraform init
 terraform plan
 terraform apply
@@ -78,17 +99,20 @@ terraform apply
 Use a remote encrypted Terraform backend for production state. Local state and
 `terraform.tfvars` are ignored by Git.
 
-The Cloudflare DNS record deliberately has proxying disabled. Cache blobs may
-be larger than Cloudflare's proxied request-body limits, so requests go directly
-to Caddy on the VPS.
+For an existing server, the Terraform state contains configuration outputs but
+no managed infrastructure resources.
 
-## Create scoped R2 credentials
+## Create R2 storage and DNS
 
-After Terraform creates the bucket, create an R2 API token with Object Read &
-Write permission scoped only to that bucket. Save its Access Key ID and Secret
-Access Key; Cloudflare displays the secret only once. The general Cloudflare API
-token used by Terraform and the S3 token used by mise-cache are intentionally
-separate.
+Create the `mise-cache-production` R2 bucket with Standard storage in Eastern
+North America, then create an R2 API token with Object Read & Write permission
+scoped only to that bucket. Save its Access Key ID and Secret Access Key;
+Cloudflare displays the secret only once.
+
+Create a DNS-only A record from `cache.mise.jdx.dev` to the Terraform
+`server_ipv4` output. Do not enable the Cloudflare proxy: cache blobs may be
+larger than proxied request-body limits, so requests must go directly to Caddy
+on the VPS.
 
 ## Deploy the service
 
@@ -100,15 +124,20 @@ export MISE_CACHE_IMAGE=ghcr.io/jdx/mise-cache@sha256:<64-hex-digit-digest>
 export MISE_CACHE_DATABASE_PASSWORD="$(openssl rand -hex 24)"
 export R2_ACCESS_KEY_ID=...
 export R2_SECRET_ACCESS_KEY=...
-export OVH_SSH_SOURCE_CIDR="203.0.113.10/32"
+export OVH_SSH_HOST="mise-cache-prod.example-tailnet.ts.net"
+export OVH_SSH_SOURCE_CIDR="$(tailscale ip -4)/32"
 ./deploy/ovh/deploy.sh
 ```
 
-`OVH_SSH_SOURCE_CIDR` is required: there is no world-open default. Mise also
-checks the active SSH connection against this rule and `OVH_SSH_PORT` before
-atomically applying the nftables policy, so an incorrect CIDR or port fails
-before it can lock out the operator. The declared policy permits TCP 80/443,
-UDP 443 for HTTP/3, and SSH only from the supplied CIDR.
+`OVH_SSH_HOST` selects a private DNS name, IP address, or OpenSSH host alias
+without changing the public address used by DNS. It defaults to the Terraform
+`server_ipv4` output. `OVH_SSH_SOURCE_CIDR` is required: there is no world-open
+default. Mise checks the active SSH connection against this rule and
+`OVH_SSH_PORT` before atomically applying the nftables policy, so an incorrect
+CIDR or port fails before it can lock out the operator. The declared policy
+permits TCP 80/443, UDP 443 for HTTP/3, SSH from the current deployment peer,
+and SSH from the Tailscale CGNAT range only when traffic arrives on
+`tailscale0`.
 
 The deploy script reads the hostname, server address, R2 endpoint, and bucket
 from Terraform outputs. It creates a mode-`0700` local bootstrap project,
@@ -119,18 +148,20 @@ environment files, and removes the staging directory. A shell trap removes the
 local project on success or failure. The caller's other environment variables
 are never forwarded.
 
-Use [fnox](https://fnox.jdx.dev/) or another secret manager to populate the
-explicit deployment environment without storing values in shell history:
-
-```sh
-fnox exec -- ./deploy/ovh/deploy.sh
-```
+Automated deployments store `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, and
+`MISE_CACHE_DATABASE_PASSWORD` in the repository's protected `production`
+GitHub Environment. Environment protection keeps these values out of ordinary
+pull-request jobs. The R2 credential remains limited by its Cloudflare bucket
+policy even if a workflow is compromised. Use a local password manager to
+populate the same variables for an emergency operator-run deployment; never
+commit their plaintext values.
 
 Ubuntu images use the `ubuntu` SSH user by default. Override `OVH_SSH_USER`,
-`OVH_SSH_PORT`, or `OVH_SSH_IDENTITY_FILE` when necessary; normal OpenSSH
-configuration and host-key policy still apply. Additional arguments are passed
-to `mise bootstrap remote`, so the complete remote plan can be inspected
-without changing the host:
+`OVH_SSH_PORT`, `OVH_SSH_HOST`, or `OVH_SSH_IDENTITY_FILE` when necessary;
+normal OpenSSH configuration and host-key policy still apply. Additional
+arguments are passed to `mise bootstrap remote`, including repeatable
+`--ssh-option` values for bastions and userspace-networking proxies. The
+complete remote plan can be inspected without changing the host:
 
 ```sh
 ./deploy/ovh/deploy.sh --dry-run
@@ -156,7 +187,7 @@ deploying for another repository owner.
 
 ```sh
 curl --fail "$(terraform -chdir=deploy/ovh/terraform output -raw cache_url)/v1/status"
-ssh ubuntu@"$(terraform -chdir=deploy/ovh/terraform output -raw server_ipv4)" \
+ssh ubuntu@"$OVH_SSH_HOST" \
   'cd /opt/mise-cache && sudo docker compose ps'
 ```
 

--- a/deploy/ovh/bootstrap/mise.toml
+++ b/deploy/ovh/bootstrap/mise.toml
@@ -95,6 +95,15 @@ action = "allow"
 port = 443
 protocol = "udp"
 
+[[bootstrap.linux.firewall.rules]]
+name = "tailscale-ssh"
+direction = "incoming"
+action = "allow"
+port = 22
+protocol = "tcp"
+source = "100.64.0.0/10"
+interface = "tailscale0"
+
 [bootstrap.compose.mise-cache]
 project_dir = "/opt/mise-cache"
 files = ["compose.yaml"]

--- a/deploy/ovh/deploy.sh
+++ b/deploy/ovh/deploy.sh
@@ -74,10 +74,16 @@ if [[ -n ${OVH_SSH_IDENTITY_FILE:-} && ! -r $OVH_SSH_IDENTITY_FILE ]]; then
 fi
 
 server_ip="$("$terraform_command" -chdir="$terraform_dir" output -raw server_ipv4)"
+ssh_host=${OVH_SSH_HOST:-$server_ip}
 cache_url="$("$terraform_command" -chdir="$terraform_dir" output -raw cache_url)"
 r2_bucket="$("$terraform_command" -chdir="$terraform_dir" output -raw r2_bucket)"
 r2_endpoint="$("$terraform_command" -chdir="$terraform_dir" output -raw r2_endpoint)"
 cache_url=${cache_url%/}
+
+if [[ ! $ssh_host =~ ^[A-Za-z0-9_.:-]+$ ]]; then
+  echo "OVH_SSH_HOST must be an IP address or SSH host name without whitespace" >&2
+  exit 1
+fi
 
 if [[ $cache_url != https://* ]]; then
   echo "Terraform cache_url must use https://" >&2
@@ -166,7 +172,7 @@ ssh_source_cidr=$(jq -Rn --arg value "$OVH_SSH_SOURCE_CIDR" '$value')
 
 remote_args=(
   bootstrap remote
-  --host "$ssh_user@$server_ip"
+  --host "$ssh_user@$ssh_host"
   --source "$project_dir"
   --only "packages,files,services,firewall,compose"
   --update

--- a/deploy/ovh/terraform/.terraform.lock.hcl
+++ b/deploy/ovh/terraform/.terraform.lock.hcl
@@ -1,23 +1,6 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
-provider "registry.terraform.io/cloudflare/cloudflare" {
-  version     = "5.22.0"
-  constraints = "~> 5.0"
-  hashes = [
-    "h1:u3j/+0nmwTHvVg4lTziT8c9YvzGLlJOmFEOv/42yPuQ=",
-    "zh:45f3b7c50254b1da1dc21e77e03cd1e931cab40fb75c7cba822a53ed54cd232e",
-    "zh:8437138c0af1a1a557b516ca42dae54499933cc81072396abe7eefd267218f79",
-    "zh:9140044a3c909e1a2767c8b2dd95370b8152bcbc7cb26c47e376e81f75512d32",
-    "zh:b69a80d2bb33059e93dec94490065fe210c621d8bdf32d745b1d1972aa85abbf",
-    "zh:ca4bf16742a7e59319a482f003d32f6f6abbc5fbf862916ce1a136278e6d420d",
-    "zh:cd767016ea7382e384e560f6ddb302637ecb1b53ece15c9326032010effe6c33",
-    "zh:d952f92ae1a688ed376757127ae1aa3b625571bf1fc606214a5822eae98213e0",
-    "zh:f5213814c8ca0d736623438b283143b9a7f98e72ca4992eb906966e7f8cc383b",
-    "zh:f809ab383cca0a5f83072981c64208cbd7fa67e986a86ee02dd2c82333221e32",
-  ]
-}
-
 provider "registry.terraform.io/ovh/ovh" {
   version     = "2.18.0"
   constraints = "~> 2.17"

--- a/deploy/ovh/terraform/main.tf
+++ b/deploy/ovh/terraform/main.tf
@@ -1,9 +1,17 @@
-data "ovh_me" "account" {}
+locals {
+  create_vps = var.existing_server_ipv4 == null
+}
+
+data "ovh_me" "account" {
+  count = local.create_vps ? 1 : 0
+}
 
 resource "ovh_vps" "cache" {
+  count = local.create_vps ? 1 : 0
+
   display_name         = var.name
   image_id             = var.image_id
-  ovh_subsidiary       = data.ovh_me.account.ovh_subsidiary
+  ovh_subsidiary       = data.ovh_me.account[0].ovh_subsidiary
   public_ssh_key       = var.public_ssh_key
   do_not_send_password = true
 
@@ -22,30 +30,33 @@ resource "ovh_vps" "cache" {
       }
     ]
   }]
+
+  lifecycle {
+    prevent_destroy = true
+
+    precondition {
+      condition     = var.plan_code != null
+      error_message = "plan_code is required when existing_server_ipv4 is unset."
+    }
+    precondition {
+      condition     = var.image_id != null
+      error_message = "image_id is required when existing_server_ipv4 is unset."
+    }
+    precondition {
+      condition     = var.public_ssh_key != null
+      error_message = "public_ssh_key is required when existing_server_ipv4 is unset."
+    }
+  }
 }
 
 data "ovh_vps" "cache" {
-  service_name = ovh_vps.cache.name
+  count        = local.create_vps ? 1 : 0
+  service_name = ovh_vps.cache[0].name
 }
 
 locals {
-  vps_addresses = [for address in data.ovh_vps.cache.ips : split("/", address)[0]]
-  vps_ipv4      = one([for address in local.vps_addresses : address if !strcontains(address, ":")])
-}
-
-resource "cloudflare_r2_bucket" "cache" {
-  account_id    = var.cloudflare_account_id
-  name          = var.r2_bucket
-  location      = "enam"
-  storage_class = "Standard"
-}
-
-resource "cloudflare_dns_record" "cache" {
-  zone_id = var.cloudflare_zone_id
-  name    = var.domain
-  content = local.vps_ipv4
-  type    = "A"
-  ttl     = 300
-  proxied = false
-  comment = "mise-cache origin managed by Terraform"
+  created_vps_addresses = local.create_vps ? [for address in data.ovh_vps.cache[0].ips : split("/", address)[0]] : []
+  vps_ipv4 = local.create_vps ? one([
+    for address in local.created_vps_addresses : address if !strcontains(address, ":")
+  ]) : var.existing_server_ipv4
 }

--- a/deploy/ovh/terraform/outputs.tf
+++ b/deploy/ovh/terraform/outputs.tf
@@ -3,7 +3,7 @@ output "server_ipv4" {
 }
 
 output "vps_service_name" {
-  value = ovh_vps.cache.name
+  value = local.create_vps ? ovh_vps.cache[0].name : null
 }
 
 output "cache_url" {
@@ -15,5 +15,5 @@ output "r2_endpoint" {
 }
 
 output "r2_bucket" {
-  value = cloudflare_r2_bucket.cache.name
+  value = var.r2_bucket
 }

--- a/deploy/ovh/terraform/terraform.tfvars.example
+++ b/deploy/ovh/terraform/terraform.tfvars.example
@@ -1,9 +1,11 @@
 domain                  = "cache.mise.jdx.dev"
 cloudflare_account_id   = "replace-me"
-cloudflare_zone_id      = "replace-me"
 r2_bucket               = "mise-cache-production"
-plan_code               = "replace-with-current-vps-1-plan-code"
-image_id                = "replace-with-current-ubuntu-image-id"
-public_ssh_key           = "ssh-ed25519 AAAA... operator@example"
+# existing_server_ipv4  = "replace-with-existing-vps-ipv4"
 datacenter               = "US-EAST-VA"
 operating_system         = "Ubuntu 24.04"
+
+# Leave existing_server_ipv4 unset and provide these values to order a new VPS.
+# plan_code     = "replace-with-current-vps-1-plan-code"
+# image_id      = "replace-with-current-ubuntu-image-id"
+# public_ssh_key = "ssh-ed25519 AAAA... operator@example"

--- a/deploy/ovh/terraform/variables.tf
+++ b/deploy/ovh/terraform/variables.tf
@@ -14,19 +14,32 @@ variable "cloudflare_account_id" {
   type        = string
 }
 
-variable "cloudflare_zone_id" {
-  description = "Cloudflare zone ID containing the cache hostname."
+variable "r2_bucket" {
+  description = "Existing R2 bucket name for cache blobs."
   type        = string
 }
 
-variable "r2_bucket" {
-  description = "Globally unique R2 bucket name for cache blobs."
+variable "existing_server_ipv4" {
+  description = "Existing VPS IPv4 address to adopt instead of ordering a new OVH VPS."
   type        = string
+  default     = null
+  nullable    = true
+
+  validation {
+    condition = (
+      var.existing_server_ipv4 == null ||
+      (!strcontains(var.existing_server_ipv4, ":") &&
+      can(cidrhost("${var.existing_server_ipv4}/32", 0)))
+    )
+    error_message = "existing_server_ipv4 must be a valid IPv4 address."
+  }
 }
 
 variable "plan_code" {
   description = "Currently available OVH US VPS plan code from the OVH order catalog."
   type        = string
+  default     = null
+  nullable    = true
 }
 
 variable "plan_duration" {
@@ -56,9 +69,13 @@ variable "operating_system" {
 variable "image_id" {
   description = "OVH Ubuntu image ID used to install the supplied SSH key."
   type        = string
+  default     = null
+  nullable    = true
 }
 
 variable "public_ssh_key" {
   description = "Public SSH key installed on the VPS."
   type        = string
+  default     = null
+  nullable    = true
 }

--- a/deploy/ovh/terraform/versions.tf
+++ b/deploy/ovh/terraform/versions.tf
@@ -2,10 +2,6 @@ terraform {
   required_version = ">= 1.8.0"
 
   required_providers {
-    cloudflare = {
-      source  = "cloudflare/cloudflare"
-      version = "~> 5.0"
-    }
     ovh = {
       source  = "ovh/ovh"
       version = "~> 2.17"
@@ -13,5 +9,6 @@ terraform {
   }
 }
 
-provider "cloudflare" {}
-provider "ovh" {}
+provider "ovh" {
+  ignore_init_error = !local.create_vps
+}

--- a/deploy/ovh/test-deploy.sh
+++ b/deploy/ovh/test-deploy.sh
@@ -66,6 +66,7 @@ common_env=(
   "CAPTURE_DIR=$test_root/capture"
   "MISE_CACHE_DATABASE_PASSWORD=database_password_123456"
   "MISE_CACHE_IMAGE=ghcr.io/jdx/mise-cache@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  "OVH_SSH_HOST=mise-cache-prod.tailnet.example"
   "PATH=$test_root/bin:$PATH"
   "R2_ACCESS_KEY_ID=r2-access-key"
   "R2_SECRET_ACCESS_KEY=r2-secret-key"
@@ -93,7 +94,7 @@ env "${common_env[@]}" \
 
 grep -Fxq 'bootstrap' "$test_root/capture/args"
 grep -Fxq 'remote' "$test_root/capture/args"
-grep -Fxq 'ubuntu@192.0.2.10' "$test_root/capture/args"
+grep -Fxq 'ubuntu@mise-cache-prod.tailnet.example' "$test_root/capture/args"
 grep -Fxq 'packages,files,services,firewall,compose' "$test_root/capture/args"
 grep -Fxq -- '--port' "$test_root/capture/args"
 grep -Fxq '2222' "$test_root/capture/args"


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a></sub>

## Summary
- allow Terraform to adopt an existing OVH VPS without ordering or managing another server
- keep deployment SSH on the private Tailscale path while public HTTPS uses the server IPv4 address
- remove Cloudflare resources and provider credentials from Terraform; R2 storage and DNS are one-time manual setup
- document bucket-scoped R2 credentials stored in a protected GitHub `production` Environment
- prevent accidental destruction when transitioning a Terraform-managed VPS into adoption mode

## Validation
- Terraform 1.14.9 formatting, initialization, and validation
- existing-server Terraform plan without OVH or Cloudflare credentials
- ShellCheck 0.11.0
- `deploy/ovh/test-deploy.sh`
- live private SSH through the isolated tailnet
- live `mise bootstrap remote --dry-run` against the clean Ubuntu 24.04 OVH VPS

The first production deploy and cache qualification remain intentionally pending until the manually scoped R2 credentials and DNS record are configured.

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production provisioning and SSH/firewall behavior (Tailscale path, VPS adoption); misconfiguration could affect deploy access or Terraform state transitions, though runtime app logic is barely touched.
> 
> **Overview**
> **OVH Terraform** can either order a new VPS or **adopt an existing host** via `existing_server_ipv4`, with OVH API credentials and VPS resources skipped in adoption mode (`ignore_init_error`, conditional `ovh_vps`). **Cloudflare provider resources** (R2 bucket, DNS) are removed; bucket name and account ID are inputs only, with R2 and DNS documented as one-time manual setup. New VPS orders get **`prevent_destroy`** and documented steps to move a managed VPS into adoption via state rm.
> 
> **Deploy path** adds **`OVH_SSH_HOST`** (defaults to public `server_ipv4`) so `mise bootstrap remote` can use a Tailscale hostname while public HTTPS/DNS still use the VPS IPv4. Bootstrap firewall gains **SSH on `tailscale0`** from `100.64.0.0/10`. Docs and CI add an **existing-server `terraform plan`** without OVH/Cloudflare creds; secrets guidance shifts to a protected GitHub **`production`** environment.
> 
> **Rust:** `postgres.rs` hoists the SQLx migrator to a static and adds a unit test that embedded migration versions are unique.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 201344d43adcf70065a86d4ba4853aff357c3a3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->