### PR TITLE
feat(deploy): deploy main images to OVH

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -66,6 +66,131 @@ jobs:
       tag: ${{ needs.release.outputs.tag }}
       publish_main: true
 
+  deploy:
+    name: Deploy production
+    needs: image
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    environment: production
+    concurrency:
+      group: mise-cache-production
+      cancel-in-progress: false
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      CACHE_URL: https://cache.mise.jdx.dev
+      CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID || secrets.CLOUDFLARE_ACCOUNT_ID }}
+      MISE_CACHE_DATABASE_PASSWORD: ${{ secrets.MISE_CACHE_DATABASE_PASSWORD }}
+      R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+      R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+      TS_AUDIENCE: ${{ secrets.TS_AUDIENCE }}
+      TS_OAUTH_CLIENT_ID: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+    steps:
+      - name: Validate deployment configuration
+        run: |
+          missing=()
+          for name in \
+            CLOUDFLARE_ACCOUNT_ID \
+            MISE_CACHE_DATABASE_PASSWORD \
+            R2_ACCESS_KEY_ID \
+            R2_SECRET_ACCESS_KEY \
+            TS_AUDIENCE \
+            TS_OAUTH_CLIENT_ID; do
+            if [ -z "${!name}" ]; then
+              missing+=("$name")
+            fi
+          done
+          if (( ${#missing[@]} )); then
+            printf '::error::Missing production configuration: %s\n' "${missing[*]}"
+            exit 1
+          fi
+          if [[ ! "$CLOUDFLARE_ACCOUNT_ID" =~ ^[0-9a-f]{32}$ ]]; then
+            echo '::error::CLOUDFLARE_ACCOUNT_ID must be a 32-character lowercase hexadecimal account ID'
+            exit 1
+          fi
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3
+        with:
+          terraform_version: 1.14.9
+
+      - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
+        with:
+          version: 2026.8.2
+          install: false
+          cache: false
+
+      - name: Join the deployment tailnet
+        uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8 # v4.1.3
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          audience: ${{ secrets.TS_AUDIENCE }}
+          tags: tag:mise-cache-ci
+          ping: mise-cache-prod.tail13c301.ts.net
+
+      - name: Configure deployment outputs
+        env:
+          TF_VAR_cloudflare_account_id: ${{ env.CLOUDFLARE_ACCOUNT_ID }}
+          TF_VAR_domain: cache.mise.jdx.dev
+          TF_VAR_existing_server_ipv4: 15.204.81.200
+          TF_VAR_r2_bucket: mise-cache-production
+        run: |
+          terraform -chdir=deploy/ovh/terraform init -backend=false -input=false
+          terraform -chdir=deploy/ovh/terraform apply -auto-approve -input=false
+
+      - name: Deploy immutable image
+        env:
+          MISE_CACHE_DEPLOY_GITHUB_WORKFLOW_REF: jdx/mise-cache/.github/workflows/release-plz.yml@refs/heads/main
+          MISE_CACHE_IMAGE: ${{ format('ghcr.io/jdx/mise-cache@{0}', needs.image.outputs.digest) }}
+          OVH_SSH_HOST: mise-cache-prod.tail13c301.ts.net
+        run: |
+          OVH_SSH_SOURCE_CIDR="$(tailscale ip -4)/32"
+          export OVH_SSH_SOURCE_CIDR
+          ./deploy/ovh/deploy.sh \
+            --ssh-option=StrictHostKeyChecking=accept-new
+
+      - name: Qualify OIDC, PostgreSQL, and R2
+        env:
+          CACHE_NAMESPACE: jdx/mise-cache
+        run: |
+          response=$(curl --fail --silent --show-error \
+            --get \
+            --data-urlencode "audience=$CACHE_URL" \
+            -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "$ACTIONS_ID_TOKEN_REQUEST_URL")
+          token=$(jq -er '.value | strings | select(length > 0)' <<<"$response")
+          echo "::add-mask::$token"
+
+          temporary_dir=$(mktemp -d "${RUNNER_TEMP}/mise-cache-qualification.XXXXXXXX")
+          trap 'rm -rf -- "$temporary_dir"' EXIT
+          printf 'mise-cache production qualification %s\n' "$GITHUB_SHA" >"$temporary_dir/input"
+          digest=$(sha256sum "$temporary_dir/input" | cut -d ' ' -f 1)
+          size=$(wc -c <"$temporary_dir/input")
+          blob_url="$CACHE_URL/v1/blobs/sha256/$digest/$size"
+          headers=(
+            -H "Authorization: Bearer $token"
+            -H "If-None-Match: *"
+            -H "Mise-Cache-Namespace: $CACHE_NAMESPACE"
+            -H "Mise-Cache-Protocol: 1"
+          )
+
+          curl --fail --silent --show-error \
+            "${headers[@]}" \
+            --upload-file "$temporary_dir/input" \
+            "$blob_url"
+          curl --fail --silent --show-error \
+            "${headers[@]}" \
+            --output "$temporary_dir/output" \
+            "$blob_url"
+          cmp "$temporary_dir/input" "$temporary_dir/output"
+          echo "Production cache write/read qualification passed." >> "$GITHUB_STEP_SUMMARY"
+
   publish-release:
     name: Publish GitHub release
     needs: [release, image]

--- a/deploy/ovh/README.md
+++ b/deploy/ovh/README.md
@@ -178,10 +178,15 @@ GitHub OIDC is configured with these server-enforced grants:
 - `jdx/mise` on `main`: read/write;
 - `jdx/mise` tag workflows: read/write;
 - pull-request workflows: read-only; and
-- other push workflows: read-only.
+- other push workflows: read-only; and
+- the exact `jdx/mise-cache` production deployment workflow: read/write for
+  its isolated qualification namespace.
 
 Override `MISE_CACHE_GITHUB_REPOSITORY` and `MISE_CACHE_GITHUB_OWNER_ID` when
-deploying for another repository owner.
+deploying for another repository owner. Override
+`MISE_CACHE_DEPLOY_GITHUB_REPOSITORY` and
+`MISE_CACHE_DEPLOY_GITHUB_WORKFLOW_REF` together when deployment is managed by
+another repository or workflow.
 
 ## Verify and operate
 

--- a/deploy/ovh/deploy.sh
+++ b/deploy/ovh/deploy.sh
@@ -49,6 +49,8 @@ fi
 
 github_repository=${MISE_CACHE_GITHUB_REPOSITORY:-jdx/mise}
 github_owner_id=${MISE_CACHE_GITHUB_OWNER_ID:-216188}
+deployment_repository=${MISE_CACHE_DEPLOY_GITHUB_REPOSITORY:-jdx/mise-cache}
+deployment_workflow_ref=${MISE_CACHE_DEPLOY_GITHUB_WORKFLOW_REF:-jdx/mise-cache/.github/workflows/release-plz.yml@refs/heads/main}
 ssh_user=${OVH_SSH_USER:-ubuntu}
 ssh_port=${OVH_SSH_PORT:-22}
 
@@ -58,6 +60,14 @@ if [[ ! $github_repository =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
 fi
 if [[ ! $github_owner_id =~ ^[0-9]+$ ]]; then
   echo "MISE_CACHE_GITHUB_OWNER_ID must be numeric" >&2
+  exit 1
+fi
+if [[ ! $deployment_repository =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
+  echo "MISE_CACHE_DEPLOY_GITHUB_REPOSITORY must be an owner/repository name" >&2
+  exit 1
+fi
+if [[ ! $deployment_workflow_ref =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/[.]github/workflows/[A-Za-z0-9_.-]+[.]ya?ml@refs/heads/[A-Za-z0-9_./-]+$ ]]; then
+  echo "MISE_CACHE_DEPLOY_GITHUB_WORKFLOW_REF must identify a workflow on a branch" >&2
   exit 1
 fi
 if [[ ! $ssh_user =~ ^[A-Za-z_][A-Za-z0-9_-]*$ ]]; then
@@ -101,6 +111,8 @@ fi
 
 oidc_providers=$(jq -cn \
   --arg audience "$cache_url" \
+  --arg deployment_repository "$deployment_repository" \
+  --arg deployment_workflow_ref "$deployment_workflow_ref" \
   --arg owner_id "$github_owner_id" \
   --arg repository "$github_repository" \
   '[{
@@ -110,7 +122,8 @@ oidc_providers=$(jq -cn \
       {claims: {repository: $repository, repository_owner_id: $owner_id, ref: "refs/heads/main"}, read: [$repository], write: [$repository]},
       {claims: {repository: $repository, repository_owner_id: $owner_id, ref_type: "tag"}, read: [$repository], write: [$repository]},
       {claims: {repository: $repository, repository_owner_id: $owner_id, event_name: "pull_request"}, read: [$repository], write: []},
-      {claims: {repository: $repository, repository_owner_id: $owner_id, event_name: "push"}, read: [$repository], write: []}
+      {claims: {repository: $repository, repository_owner_id: $owner_id, event_name: "push"}, read: [$repository], write: []},
+      {claims: {repository: $deployment_repository, repository_owner_id: $owner_id, environment: "production", workflow_ref: $deployment_workflow_ref}, read: [$deployment_repository], write: [$deployment_repository]}
     ]
   }]')
 

--- a/deploy/ovh/test-deploy.sh
+++ b/deploy/ovh/test-deploy.sh
@@ -53,6 +53,17 @@ printf '%s\n' "$project_dir" >"$CAPTURE_DIR/project-dir"
 grep -Fq 'POSTGRES_PASSWORD="database_password_123456"' "$project_dir/runtime/.env"
 grep -Fq 'AWS_ACCESS_KEY_ID="r2-access-key"' "$project_dir/runtime/cache.env"
 grep -Fq 'AWS_SECRET_ACCESS_KEY="r2-secret-key"' "$project_dir/runtime/cache.env"
+oidc_json=$(sed -n 's/^MISE_CACHE_OIDC_PROVIDERS_JSON=//p' "$project_dir/runtime/cache.env" | jq -c fromjson)
+jq -e '
+  .[0].rules | any(
+    .claims.repository == "jdx/mise-cache" and
+    .claims.repository_owner_id == "216188" and
+    .claims.environment == "production" and
+    .claims.workflow_ref == "jdx/mise-cache/.github/workflows/release-plz.yml@refs/heads/main" and
+    .read == ["jdx/mise-cache"] and
+    .write == ["jdx/mise-cache"]
+  )
+' <<<"$oidc_json" >/dev/null
 grep -Fq 'port = 2222' "$project_dir/mise.local.toml"
 grep -Fq 'source = "203.0.113.10/32"' "$project_dir/mise.local.toml"
 if grep -R -Fq 'must-not-be-forwarded' "$project_dir"; then


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a></sub>

## Summary
- deploy the immutable container produced for every `main` push directly after the image job succeeds
- join the isolated deployment tailnet through GitHub OIDC workload identity and authenticate with Tailscale SSH
- keep runtime credentials in the protected `production` GitHub Environment
- scope cache-server OIDC access to the exact production workflow and an isolated qualification namespace
- qualify TLS, GitHub OIDC, PostgreSQL metadata, and R2 storage with a real blob write/read after every deployment

## Safety
- deployment depends only on successful image publication, so unrelated release-PR or GitHub-release failures cannot block a ready image
- deployments serialize instead of cancelling in-progress host convergence
- container references flow directly from the image publisher and deploy by immutable digest
- no reusable Tailscale auth key or SSH private key is stored in GitHub
- R2 credentials remain restricted to the single production bucket

## Validation
- Terraform 1.14.9 formatting and validation
- ShellCheck 0.11.0
- Actionlint 1.7.7
- `deploy/ovh/test-deploy.sh`
- live deployment to `cache.mise.jdx.dev`
- live Tailscale workload identity and SSH
- live GitHub OIDC, PostgreSQL metadata, and R2 blob write/read qualification

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes production deployment automation, OIDC authorization rules, and use of production secrets/R2 credentials on every main push.
> 
> **Overview**
> Adds an automated **production deploy** path on every `main` push, running after the container image job succeeds (independent of release tagging).
> 
> The new **`deploy` job** uses the protected `production` GitHub Environment, validates required secrets, joins the host over **Tailscale** via OIDC (no stored SSH keys), runs a local Terraform apply for deployment outputs, and rolls out **`ghcr.io/jdx/mise-cache@<digest>`** through `deploy/ovh/deploy.sh` with the runner’s Tailscale IP as the SSH source CIDR. A post-deploy step requests a GitHub Actions OIDC token and **writes then reads a test blob** against `cache.mise.jdx.dev` under namespace `jdx/mise-cache` to qualify OIDC, Postgres metadata, and R2.
> 
> **`deploy.sh`** now accepts `MISE_CACHE_DEPLOY_GITHUB_REPOSITORY` and `MISE_CACHE_DEPLOY_GITHUB_WORKFLOW_REF` and injects an extra OIDC rule granting read/write only to that repo’s `production` environment on the exact workflow ref—so the deploy workflow can qualify cache access without broadening `jdx/mise` grants. Docs and **`test-deploy.sh`** are updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d1d71333ed5e7a42a88b9bd063a201ba17bdf16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->