### PR TITLE
feat(deploy): trust multiple cache repositories

### DIFF
--- a/deploy/ovh/README.md
+++ b/deploy/ovh/README.md
@@ -175,18 +175,22 @@ role-password rotation.
 
 GitHub OIDC is configured with these server-enforced grants:
 
-- `jdx/mise` on `main`: read/write;
-- `jdx/mise` tag workflows: read/write;
-- pull-request workflows: read-only; and
-- other push workflows: read-only; and
+- repositories listed in `trusted-repositories.json` on `main`: read/write;
+- tag workflows for listed repositories: read-only;
+- pull-request workflows for listed repositories: read-only;
+- other push workflows for listed repositories: read-only; and
 - the exact `jdx/mise-cache` production deployment workflow: read/write for
   its isolated qualification namespace.
 
-Override `MISE_CACHE_GITHUB_REPOSITORY` and `MISE_CACHE_GITHUB_OWNER_ID` when
-deploying for another repository owner. Override
+Each trusted repository is paired with GitHub's stable numeric
+`repository_owner_id`; repository names must be unique. Edit the checked-in
+file to change the production allowlist, or set
+`MISE_CACHE_GITHUB_REPOSITORIES_FILE` to a different JSON file for another
+installation. Override
 `MISE_CACHE_DEPLOY_GITHUB_REPOSITORY` and
+`MISE_CACHE_DEPLOY_GITHUB_OWNER_ID`, and
 `MISE_CACHE_DEPLOY_GITHUB_WORKFLOW_REF` together when deployment is managed by
-another repository or workflow.
+another repository owner or workflow.
 
 ## Verify and operate
 

--- a/deploy/ovh/deploy.sh
+++ b/deploy/ovh/deploy.sh
@@ -47,23 +47,39 @@ if [[ $OVH_SSH_SOURCE_CIDR =~ [[:space:]] ]]; then
   exit 1
 fi
 
-github_repository=${MISE_CACHE_GITHUB_REPOSITORY:-jdx/mise}
-github_owner_id=${MISE_CACHE_GITHUB_OWNER_ID:-216188}
+trusted_repositories_file=${MISE_CACHE_GITHUB_REPOSITORIES_FILE:-$script_dir/trusted-repositories.json}
 deployment_repository=${MISE_CACHE_DEPLOY_GITHUB_REPOSITORY:-jdx/mise-cache}
+deployment_owner_id=${MISE_CACHE_DEPLOY_GITHUB_OWNER_ID:-216188}
 deployment_workflow_ref=${MISE_CACHE_DEPLOY_GITHUB_WORKFLOW_REF:-jdx/mise-cache/.github/workflows/release-plz.yml@refs/heads/main}
 ssh_user=${OVH_SSH_USER:-ubuntu}
 ssh_port=${OVH_SSH_PORT:-22}
 
-if [[ ! $github_repository =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
-  echo "MISE_CACHE_GITHUB_REPOSITORY must be an owner/repository name" >&2
+if [[ ! -r $trusted_repositories_file ]]; then
+  echo "MISE_CACHE_GITHUB_REPOSITORIES_FILE is not readable: $trusted_repositories_file" >&2
   exit 1
 fi
-if [[ ! $github_owner_id =~ ^[0-9]+$ ]]; then
-  echo "MISE_CACHE_GITHUB_OWNER_ID must be numeric" >&2
+if ! trusted_repositories=$(jq -ce '
+  if type != "array" or length == 0 then
+    error("must be a non-empty array")
+  elif any(.[].repository; type != "string" or test("^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$") | not) then
+    error("repository must be an owner/repository name")
+  elif any(.[].repository_owner_id; type != "string" or test("^[0-9]+$") | not) then
+    error("repository_owner_id must be a numeric string")
+  elif ([.[].repository] | unique | length) != length then
+    error("repository names must be unique")
+  else
+    map({repository, repository_owner_id})
+  end
+' "$trusted_repositories_file"); then
+  echo "MISE_CACHE_GITHUB_REPOSITORIES_FILE is invalid: $trusted_repositories_file" >&2
   exit 1
 fi
 if [[ ! $deployment_repository =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
   echo "MISE_CACHE_DEPLOY_GITHUB_REPOSITORY must be an owner/repository name" >&2
+  exit 1
+fi
+if [[ ! $deployment_owner_id =~ ^[0-9]+$ ]]; then
+  echo "MISE_CACHE_DEPLOY_GITHUB_OWNER_ID must be numeric" >&2
   exit 1
 fi
 if [[ ! $deployment_workflow_ref =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/[.]github/workflows/[A-Za-z0-9_.-]+[.]ya?ml@refs/heads/[A-Za-z0-9_./-]+$ ]]; then
@@ -112,19 +128,24 @@ fi
 oidc_providers=$(jq -cn \
   --arg audience "$cache_url" \
   --arg deployment_repository "$deployment_repository" \
+  --arg deployment_owner_id "$deployment_owner_id" \
   --arg deployment_workflow_ref "$deployment_workflow_ref" \
-  --arg owner_id "$github_owner_id" \
-  --arg repository "$github_repository" \
+  --argjson repositories "$trusted_repositories" \
   '[{
     issuer: "https://token.actions.githubusercontent.com",
     audiences: [$audience],
-    rules: [
-      {claims: {repository: $repository, repository_owner_id: $owner_id, ref: "refs/heads/main"}, read: [$repository], write: [$repository]},
-      {claims: {repository: $repository, repository_owner_id: $owner_id, ref_type: "tag"}, read: [$repository], write: [$repository]},
-      {claims: {repository: $repository, repository_owner_id: $owner_id, event_name: "pull_request"}, read: [$repository], write: []},
-      {claims: {repository: $repository, repository_owner_id: $owner_id, event_name: "push"}, read: [$repository], write: []},
-      {claims: {repository: $deployment_repository, repository_owner_id: $owner_id, environment: "production", workflow_ref: $deployment_workflow_ref}, read: [$deployment_repository], write: [$deployment_repository]}
-    ]
+    rules: (
+      (
+        [$repositories[] as $entry | [
+          {claims: {repository: $entry.repository, repository_owner_id: $entry.repository_owner_id, ref: "refs/heads/main"}, read: [$entry.repository], write: [$entry.repository]},
+          {claims: {repository: $entry.repository, repository_owner_id: $entry.repository_owner_id, ref_type: "tag"}, read: [$entry.repository], write: []},
+          {claims: {repository: $entry.repository, repository_owner_id: $entry.repository_owner_id, event_name: "pull_request"}, read: [$entry.repository], write: []},
+          {claims: {repository: $entry.repository, repository_owner_id: $entry.repository_owner_id, event_name: "push"}, read: [$entry.repository], write: []}
+        ]] | add
+      ) + [
+        {claims: {repository: $deployment_repository, repository_owner_id: $deployment_owner_id, environment: "production", workflow_ref: $deployment_workflow_ref}, read: [$deployment_repository], write: [$deployment_repository]}
+      ]
+    )
   }]')
 
 temporary_root=${TMPDIR:-/tmp}

--- a/deploy/ovh/test-deploy.sh
+++ b/deploy/ovh/test-deploy.sh
@@ -55,14 +55,46 @@ grep -Fq 'AWS_ACCESS_KEY_ID="r2-access-key"' "$project_dir/runtime/cache.env"
 grep -Fq 'AWS_SECRET_ACCESS_KEY="r2-secret-key"' "$project_dir/runtime/cache.env"
 oidc_json=$(sed -n 's/^MISE_CACHE_OIDC_PROVIDERS_JSON=//p' "$project_dir/runtime/cache.env" | jq -c fromjson)
 jq -e '
-  .[0].rules | any(
+  .[0].rules as $rules |
+  ($rules | length == 9) and
+  (["jdx/mise", "jdx/aube"] | all(. as $repository |
+    ($rules | any(
+      .claims.repository == $repository and
+      .claims.repository_owner_id == "216188" and
+      .claims.ref == "refs/heads/main" and
+      .read == [$repository] and
+      .write == [$repository]
+    )) and
+    ($rules | any(
+      .claims.repository == $repository and
+      .claims.repository_owner_id == "216188" and
+      .claims.ref_type == "tag" and
+      .read == [$repository] and
+      .write == []
+    )) and
+    ($rules | any(
+      .claims.repository == $repository and
+      .claims.repository_owner_id == "216188" and
+      .claims.event_name == "pull_request" and
+      .read == [$repository] and
+      .write == []
+    )) and
+    ($rules | any(
+      .claims.repository == $repository and
+      .claims.repository_owner_id == "216188" and
+      .claims.event_name == "push" and
+      .read == [$repository] and
+      .write == []
+    ))
+  )) and
+  ($rules | any(
     .claims.repository == "jdx/mise-cache" and
     .claims.repository_owner_id == "216188" and
     .claims.environment == "production" and
     .claims.workflow_ref == "jdx/mise-cache/.github/workflows/release-plz.yml@refs/heads/main" and
     .read == ["jdx/mise-cache"] and
     .write == ["jdx/mise-cache"]
-  )
+  ))
 ' <<<"$oidc_json" >/dev/null
 grep -Fq 'port = 2222' "$project_dir/mise.local.toml"
 grep -Fq 'source = "203.0.113.10/32"' "$project_dir/mise.local.toml"
@@ -95,6 +127,16 @@ if env "${common_env[@]}" \
   OVH_SSH_SOURCE_CIDR=203.0.113.10/32 \
   "$script_dir/deploy.sh" --dry-run >/dev/null 2>&1; then
   echo "deploy.sh accepted an image that was not pinned by digest" >&2
+  exit 1
+fi
+
+invalid_repositories="$test_root/invalid-repositories.json"
+printf '%s\n' '[{"repository":"jdx/mise","repository_owner_id":"216188"},{"repository":"jdx/mise","repository_owner_id":"216188"}]' >"$invalid_repositories"
+if env "${common_env[@]}" \
+  MISE_CACHE_GITHUB_REPOSITORIES_FILE="$invalid_repositories" \
+  OVH_SSH_SOURCE_CIDR=203.0.113.10/32 \
+  "$script_dir/deploy.sh" --dry-run >/dev/null 2>&1; then
+  echo "deploy.sh accepted duplicate trusted repositories" >&2
   exit 1
 fi
 

--- a/deploy/ovh/trusted-repositories.json
+++ b/deploy/ovh/trusted-repositories.json
@@ -1,0 +1,10 @@
+[
+  {
+    "repository": "jdx/mise",
+    "repository_owner_id": "216188"
+  },
+  {
+    "repository": "jdx/aube",
+    "repository_owner_id": "216188"
+  }
+]


### PR DESCRIPTION
## Summary
- replace the single trusted GitHub repository setting with a validated checked-in allowlist
- authorize `jdx/mise` and `jdx/aube` with exact repository and owner claims
- keep non-main pushes, pull requests, and tags read-only while preserving the isolated deployment grant

## Validation
- `mise exec shellcheck@0.11.0 -- shellcheck deploy/ovh/deploy.sh deploy/ovh/test-deploy.sh`
- `deploy/ovh/test-deploy.sh`
- `git diff --check`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes server-enforced GitHub OIDC authorization (who can read/write the cache), including making tag workflows read-only for trusted repos; misconfiguration could block CI or widen trust if the allowlist is wrong.
> 
> **Overview**
> **Replaces single-repo GitHub OIDC env vars** (`MISE_CACHE_GITHUB_REPOSITORY` / `MISE_CACHE_GITHUB_OWNER_ID`) with a checked-in **`trusted-repositories.json`** allowlist (override via `MISE_CACHE_GITHUB_REPOSITORIES_FILE`). `deploy.sh` validates the JSON (non-empty, valid `owner/repo`, numeric `repository_owner_id`, unique names) and **emits OIDC rules per listed repo**: `main` gets read/write; tag, pull_request, and push workflows get read-only.
> 
> Adds **`jdx/aube`** to the default allowlist alongside `jdx/mise`. Deployment workflow trust is unchanged in spirit but uses **`MISE_CACHE_DEPLOY_GITHUB_OWNER_ID`** (default `216188`) instead of the removed single-repo owner id. README documents the new model.
> 
> **`test-deploy.sh`** expects nine OIDC rules (two trusted repos × four rules + deployment rule) and rejects duplicate repository entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d43d32be677e4bdbb21c1b9ec8ede2204d7b63b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GitHub OIDC deployment access now supports multiple trusted repositories through a configurable allowlist.
  * Permissions are differentiated by event type, with write access limited to approved main-branch workflows.
  * Deployment settings can be customized for alternate repository lists and deployment workflow references.

* **Bug Fixes**
  * Added validation to reject empty or duplicate trusted repository entries.
  * Expanded deployment checks to verify access rules across branches, tags, pull requests, and pushes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->