### PR TITLE
perf(protocol): stream blob packs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,6 +104,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1810,6 +1832,7 @@ name = "mise-cache"
 version = "0.1.1"
 dependencies = [
  "anyhow",
+ "async-stream",
  "async-trait",
  "aws-config",
  "aws-sdk-s3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ include = [
 
 [dependencies]
 anyhow = "1"
+async-stream = "0.3"
 async-trait = "0.1"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "default-https-client", "rt-tokio"] }
 aws-sdk-s3 = { version = "1", default-features = false, features = ["behavior-version-latest", "default-https-client", "rt-tokio"] }

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 - Static and OIDC bearer authorization with per-namespace read/write grants
 - Recursive output-tree validation before an action result becomes visible
 - Typed action and client-metadata validation with kind negotiation
-- Batch missing-blob queries and Prometheus metrics
+- Batch missing-blob queries, streaming blob packs, and Prometheus metrics
 - Docker Compose, Helm, and Terraform-managed OVH deployments
 
 ## Quick start
@@ -161,6 +161,7 @@ All cache requests send `Mise-Cache-Namespace` and, unless anonymous access is e
 - `GET /v1/capabilities`
 - `GET|PUT /v1/blobs/{algorithm}/{hash}/{size}`
 - `POST /v1/blobs:missing`
+- `POST /v1/blobs:pack`
 - `GET|PUT /v1/action-results/{algorithm}/{hash}/{size}`
 - `GET|PUT /v1/action-manifests/{algorithm}/{hash}/{size}`
 - `GET /metrics`
@@ -168,6 +169,8 @@ All cache requests send `Mise-Cache-Namespace` and, unless anonymous access is e
 Blobs and action results are immutable. Repeating an identical write is idempotent; attempting to replace an existing action result returns `409 Conflict`. The server verifies uploaded content and every blob reachable from result metadata and output trees before publishing an action result. Content digests inside an action descriptor identify local inputs for key construction; they are not CAS references, and clients do not upload source inputs.
 
 Task action manifests are mutable discovery indexes for fresh workers. Their stable key is the BLAKE3 digest of the canonical task-manifest selector. Writes use optimistic concurrency: create with `If-None-Match: *`, or update the ETag returned by `GET` with `If-Match`. A stale update returns `412 Precondition Failed`, so clients must read, merge, and retry without dropping actions learned by another worker.
+
+Servers advertising `features.blob_packs` accept the same digest-list JSON as `blobs:missing` at `POST /v1/blobs:pack`. The response media type is `application/vnd.mise.cache-blob-pack.v1`. It begins with the eight-byte `MISEPK01` magic and then streams visible blobs in request order. Each blob is framed by a one-byte algorithm (`1` for BLAKE3, `2` for SHA-256), its raw 32-byte hash, an unsigned big-endian 64-bit size, and exactly that many content bytes. Missing or unauthorized blobs are omitted, duplicate requests are emitted once, and clients must verify every digest before admitting content to local CAS. The aggregate declared size is bounded by `MISE_CACHE_MAX_BLOB_BYTES` and advertised as `limits.max_pack_bytes`.
 
 `GET /v1/capabilities` advertises the action kinds and exact schema versions accepted by the server. Action-result keys use BLAKE3. Version 1 accepts task and rustc action and metadata schema version 1. Rustc results require an output directory tree plus metadata referencing raw stdout and stderr blobs so clients can replay compiler diagnostics byte-for-byte.
 

--- a/src/metadata/memory.rs
+++ b/src/metadata/memory.rs
@@ -16,12 +16,17 @@ pub struct MemoryMetadata {
 
 #[async_trait]
 impl MetadataStore for MemoryMetadata {
-    async fn blob_visible(&self, namespace: &str, digest: &Digest) -> anyhow::Result<bool> {
-        Ok(self
-            .blobs
-            .read()
-            .expect("metadata lock poisoned")
-            .contains(&(namespace.to_owned(), digest.clone())))
+    async fn visible_blobs(
+        &self,
+        namespace: &str,
+        digests: &[Digest],
+    ) -> anyhow::Result<Vec<Digest>> {
+        let blobs = self.blobs.read().expect("metadata lock poisoned");
+        Ok(digests
+            .iter()
+            .filter(|digest| blobs.contains(&(namespace.to_owned(), (*digest).clone())))
+            .cloned()
+            .collect())
     }
 
     async fn register_blob(&self, namespace: &str, digest: &Digest) -> anyhow::Result<()> {

--- a/src/metadata/mod.rs
+++ b/src/metadata/mod.rs
@@ -28,7 +28,17 @@ pub enum ManifestCommitOutcome {
 
 #[async_trait]
 pub trait MetadataStore: Send + Sync {
-    async fn blob_visible(&self, namespace: &str, digest: &Digest) -> anyhow::Result<bool>;
+    async fn visible_blobs(
+        &self,
+        namespace: &str,
+        digests: &[Digest],
+    ) -> anyhow::Result<Vec<Digest>>;
+    async fn blob_visible(&self, namespace: &str, digest: &Digest) -> anyhow::Result<bool> {
+        Ok(!self
+            .visible_blobs(namespace, std::slice::from_ref(digest))
+            .await?
+            .is_empty())
+    }
     async fn register_blob(&self, namespace: &str, digest: &Digest) -> anyhow::Result<()>;
     async fn get(&self, namespace: &str, action: &Digest) -> anyhow::Result<Option<ActionResult>>;
     async fn commit(

--- a/src/metadata/postgres.rs
+++ b/src/metadata/postgres.rs
@@ -18,6 +18,13 @@ impl PostgresMetadata {
     }
 }
 
+fn representable_digests(digests: &[Digest]) -> Vec<(&Digest, i64)> {
+    digests
+        .iter()
+        .filter_map(|digest| i64::try_from(digest.size).ok().map(|size| (digest, size)))
+        .collect()
+}
+
 #[async_trait]
 impl MetadataStore for PostgresMetadata {
     async fn visible_blobs(
@@ -25,21 +32,19 @@ impl MetadataStore for PostgresMetadata {
         namespace: &str,
         digests: &[Digest],
     ) -> anyhow::Result<Vec<Digest>> {
+        let digests = representable_digests(digests);
         if digests.is_empty() {
             return Ok(Vec::new());
         }
         let algorithms = digests
             .iter()
-            .map(|digest| digest.algorithm.to_string())
+            .map(|(digest, _)| digest.algorithm.to_string())
             .collect::<Vec<_>>();
         let hashes = digests
             .iter()
-            .map(|digest| digest.hash.clone())
+            .map(|(digest, _)| digest.hash.clone())
             .collect::<Vec<_>>();
-        let sizes = digests
-            .iter()
-            .map(|digest| i64::try_from(digest.size))
-            .collect::<Result<Vec<_>, _>>()?;
+        let sizes = digests.iter().map(|(_, size)| *size).collect::<Vec<_>>();
         let rows = sqlx::query(
             "SELECT requested.ordinality \
              FROM UNNEST($2::text[], $3::text[], $4::bigint[]) WITH ORDINALITY \
@@ -63,7 +68,7 @@ impl MetadataStore for PostgresMetadata {
                 let index = usize::try_from(ordinal - 1)?;
                 digests
                     .get(index)
-                    .cloned()
+                    .map(|(digest, _)| (*digest).clone())
                     .ok_or_else(|| anyhow::anyhow!("database returned an invalid blob ordinal"))
             })
             .collect()
@@ -159,7 +164,8 @@ impl MetadataStore for PostgresMetadata {
 mod tests {
     use std::collections::BTreeSet;
 
-    use super::MIGRATOR;
+    use super::{MIGRATOR, representable_digests};
+    use crate::model::{Algorithm, Digest};
 
     #[test]
     fn embedded_migration_versions_are_unique() {
@@ -171,5 +177,24 @@ mod tests {
                 migration.version
             );
         }
+    }
+
+    #[test]
+    fn unrepresentable_blob_sizes_are_not_queried() {
+        let representable = Digest {
+            algorithm: Algorithm::Blake3,
+            hash: "0".repeat(64),
+            size: i64::MAX as u64,
+        };
+        let unrepresentable = Digest {
+            algorithm: Algorithm::Blake3,
+            hash: "1".repeat(64),
+            size: i64::MAX as u64 + 1,
+        };
+
+        assert_eq!(
+            representable_digests(&[representable.clone(), unrepresentable]),
+            vec![(&representable, i64::MAX)]
+        );
     }
 }

--- a/src/metadata/postgres.rs
+++ b/src/metadata/postgres.rs
@@ -20,10 +20,53 @@ impl PostgresMetadata {
 
 #[async_trait]
 impl MetadataStore for PostgresMetadata {
-    async fn blob_visible(&self, namespace: &str, digest: &Digest) -> anyhow::Result<bool> {
-        Ok(sqlx::query("SELECT 1 FROM namespace_blobs WHERE namespace = $1 AND algorithm = $2 AND hash = $3 AND size = $4")
-            .bind(namespace).bind(digest.algorithm.to_string()).bind(&digest.hash).bind(digest.size as i64)
-            .fetch_optional(&self.pool).await?.is_some())
+    async fn visible_blobs(
+        &self,
+        namespace: &str,
+        digests: &[Digest],
+    ) -> anyhow::Result<Vec<Digest>> {
+        if digests.is_empty() {
+            return Ok(Vec::new());
+        }
+        let algorithms = digests
+            .iter()
+            .map(|digest| digest.algorithm.to_string())
+            .collect::<Vec<_>>();
+        let hashes = digests
+            .iter()
+            .map(|digest| digest.hash.clone())
+            .collect::<Vec<_>>();
+        let sizes = digests
+            .iter()
+            .map(|digest| i64::try_from(digest.size))
+            .collect::<Result<Vec<_>, _>>()?;
+        let rows = sqlx::query(
+            "SELECT requested.ordinality \
+             FROM UNNEST($2::text[], $3::text[], $4::bigint[]) WITH ORDINALITY \
+                  AS requested(algorithm, hash, size, ordinality) \
+             JOIN namespace_blobs AS blobs \
+               ON blobs.algorithm = requested.algorithm \
+              AND blobs.hash = requested.hash \
+              AND blobs.size = requested.size \
+             WHERE blobs.namespace = $1 \
+             ORDER BY requested.ordinality",
+        )
+        .bind(namespace)
+        .bind(algorithms)
+        .bind(hashes)
+        .bind(sizes)
+        .fetch_all(&self.pool)
+        .await?;
+        rows.into_iter()
+            .map(|row| {
+                let ordinal: i64 = row.try_get("ordinality")?;
+                let index = usize::try_from(ordinal - 1)?;
+                digests
+                    .get(index)
+                    .cloned()
+                    .ok_or_else(|| anyhow::anyhow!("database returned an invalid blob ordinal"))
+            })
+            .collect()
     }
 
     async fn register_blob(&self, namespace: &str, digest: &Digest) -> anyhow::Result<()> {

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,16 +1,17 @@
 use axum::{
     Json, Router,
-    body::Body,
+    body::{Body, Bytes},
     extract::{Path, State},
     http::{HeaderMap, StatusCode, header},
     response::{IntoResponse, Response},
     routing::{get, post},
 };
-use futures_util::StreamExt;
+use futures_util::{StreamExt, TryStreamExt, stream};
 use serde::{Deserialize, Serialize};
 use sha2::Digest as _;
 use std::{
     collections::HashSet,
+    io,
     sync::{
         Arc,
         atomic::{AtomicU64, Ordering},
@@ -29,6 +30,12 @@ use crate::{
     },
     storage::{BlobStore, PutOutcome},
 };
+
+const BLOB_PACK_MEDIA_TYPE: &str = "application/vnd.mise.cache-blob-pack.v1";
+const BLOB_PACK_MAGIC: &[u8; 8] = b"MISEPK01";
+const BLOB_PACK_HEADER_BYTES: usize = 1 + 32 + 8;
+const MAX_BATCH_ITEMS: usize = 10_000;
+const MAX_PACK_STORAGE_READS: usize = 16;
 
 #[derive(Clone)]
 pub struct AppState {
@@ -66,6 +73,7 @@ pub fn router(state: AppState) -> Router {
             get(get_blob).put(put_blob),
         )
         .route("/v1/blobs:missing", post(missing_blobs))
+        .route("/v1/blobs:pack", post(pack_blobs))
         .route(
             "/v1/action-results/{algorithm}/{hash}/{size}",
             get(get_action_result).put(put_action_result),
@@ -93,8 +101,8 @@ async fn capabilities(State(state): State<AppState>) -> impl IntoResponse {
             "rustc":{"action_schema":1,"metadata_schema":1},
             "task":{"action_schema":1,"metadata_schema":1}
         },
-        "features":{"action_manifests":true,"batch":true,"resumable_uploads":false,"delegated_transfers":false},
-        "limits":{"max_batch_items":10000,"max_inline_blob_bytes":1048576,"max_blob_bytes":state.max_blob_bytes}
+        "features":{"action_manifests":true,"batch":true,"blob_packs":true,"resumable_uploads":false,"delegated_transfers":false},
+        "limits":{"max_batch_items":MAX_BATCH_ITEMS,"max_inline_blob_bytes":1048576,"max_blob_bytes":state.max_blob_bytes,"max_pack_bytes":state.max_blob_bytes}
     }))
 }
 
@@ -215,24 +223,113 @@ async fn missing_blobs(
     Json(request): Json<MissingRequest>,
 ) -> Result<Json<MissingResponse>, ApiError> {
     let namespace = state.auth.authorize(&headers, Access::Read).await?;
-    if request.digests.len() > 10_000 {
+    if request.digests.len() > MAX_BATCH_ITEMS {
         return Err(ApiError::bad_request(
             "at most 10000 digests may be checked",
         ));
     }
-    let mut missing = Vec::new();
+    for digest in &request.digests {
+        validate_digest(digest)?;
+    }
+    let visible = state
+        .metadata
+        .visible_blobs(&namespace, &request.digests)
+        .await
+        .map_err(ApiError::internal)?
+        .into_iter()
+        .collect::<HashSet<_>>();
+    let missing = request
+        .digests
+        .into_iter()
+        .filter(|digest| !visible.contains(digest))
+        .collect();
+    Ok(Json(MissingResponse { missing }))
+}
+
+async fn pack_blobs(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Json(request): Json<MissingRequest>,
+) -> Result<Response, ApiError> {
+    let namespace = state.auth.authorize(&headers, Access::Read).await?;
+    if request.digests.len() > MAX_BATCH_ITEMS {
+        return Err(ApiError::bad_request("at most 10000 digests may be packed"));
+    }
+    let mut total_bytes = 0_u64;
+    let mut seen = HashSet::new();
+    let mut requested = Vec::with_capacity(request.digests.len());
     for digest in request.digests {
         validate_digest(&digest)?;
-        if !state
-            .metadata
-            .blob_visible(&namespace, &digest)
-            .await
-            .map_err(ApiError::internal)?
-        {
-            missing.push(digest);
+        if seen.insert(digest.clone()) {
+            total_bytes = total_bytes
+                .checked_add(digest.size)
+                .ok_or_else(|| ApiError::too_large("blob pack is too large"))?;
+            if total_bytes > state.max_blob_bytes {
+                return Err(ApiError::too_large(
+                    "blob pack exceeds the configured size limit",
+                ));
+            }
+            requested.push(digest);
         }
     }
-    Ok(Json(MissingResponse { missing }))
+    let visible = state
+        .metadata
+        .visible_blobs(&namespace, &requested)
+        .await
+        .map_err(ApiError::internal)?;
+    let mut entries = Vec::with_capacity(visible.len());
+    for digest in visible {
+        entries.push((pack_blob_header(&digest)?, digest));
+    }
+    let store = state.blobs.clone();
+    let metrics = state.metrics.clone();
+    let response_stream = async_stream::try_stream! {
+        yield Bytes::from_static(BLOB_PACK_MAGIC);
+        let reads = stream::iter(entries.into_iter().map(|(header, digest)| {
+            let store = store.clone();
+            async move {
+                let blob = store
+                    .get(&digest)
+                    .await
+                    .map_err(io::Error::other)?
+                    .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "visible blob is missing from storage"))?;
+                if blob.size != digest.size {
+                    return Err(io::Error::new(io::ErrorKind::InvalidData, "stored blob size does not match its digest"));
+                }
+                Ok::<_, io::Error>((header, blob))
+            }
+        }));
+        let mut reads = reads.buffered(MAX_PACK_STORAGE_READS);
+        while let Some(entry) = reads.next().await {
+            let (header, mut blob) = entry?;
+            yield header;
+            while let Some(chunk) = blob.stream.next().await {
+                yield chunk?;
+            }
+            metrics.blob_hits.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+    .map_err(|error: io::Error| error);
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, BLOB_PACK_MEDIA_TYPE)
+        .body(Body::from_stream(response_stream))
+        .map_err(ApiError::internal)
+}
+
+fn pack_blob_header(digest: &Digest) -> Result<Bytes, ApiError> {
+    let hash = hex::decode(&digest.hash).map_err(ApiError::bad_request)?;
+    if hash.len() != 32 {
+        return Err(ApiError::bad_request("invalid digest hash length"));
+    }
+    let mut header = Vec::with_capacity(BLOB_PACK_HEADER_BYTES);
+    header.push(match digest.algorithm {
+        Algorithm::Blake3 => 1,
+        Algorithm::Sha256 => 2,
+    });
+    header.extend_from_slice(&hash);
+    header.extend_from_slice(&digest.size.to_be_bytes());
+    Ok(Bytes::from(header))
 }
 
 async fn get_action_result(
@@ -896,6 +993,39 @@ mod tests {
         }
     }
 
+    fn decode_blob_pack(bytes: &[u8]) -> Vec<(Digest, Vec<u8>)> {
+        assert!(bytes.starts_with(BLOB_PACK_MAGIC));
+        let mut offset = BLOB_PACK_MAGIC.len();
+        let mut entries = Vec::new();
+        while offset < bytes.len() {
+            assert!(bytes.len() - offset >= BLOB_PACK_HEADER_BYTES);
+            let algorithm = match bytes[offset] {
+                1 => Algorithm::Blake3,
+                2 => Algorithm::Sha256,
+                value => panic!("unexpected blob pack algorithm {value}"),
+            };
+            let hash = hex::encode(&bytes[offset + 1..offset + 33]);
+            let size = u64::from_be_bytes(
+                bytes[offset + 33..offset + BLOB_PACK_HEADER_BYTES]
+                    .try_into()
+                    .unwrap(),
+            );
+            offset += BLOB_PACK_HEADER_BYTES;
+            let end = offset + usize::try_from(size).unwrap();
+            assert!(end <= bytes.len());
+            entries.push((
+                Digest {
+                    algorithm,
+                    hash,
+                    size,
+                },
+                bytes[offset..end].to_vec(),
+            ));
+            offset = end;
+        }
+        entries
+    }
+
     fn canonical(value: serde_json::Value) -> Vec<u8> {
         serde_json::to_vec(&value).unwrap()
     }
@@ -1040,6 +1170,69 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn streams_visible_blobs_in_a_deduplicated_pack() {
+        let (app, _directory) = test_app().await;
+        let first_bytes = b"first cached output";
+        let second_bytes = b"second cached output";
+        let first = upload_blob(&app, first_bytes).await;
+        let second = upload_blob(&app, second_bytes).await;
+        let missing = digest(b"missing cached output");
+        let body = serde_json::to_vec(&serde_json::json!({
+            "digests":[second, missing, first, second]
+        }))
+        .unwrap();
+        let response = app
+            .oneshot(request("POST", "/v1/blobs:pack".into(), Body::from(body)))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response.headers().get(header::CONTENT_TYPE).unwrap(),
+            BLOB_PACK_MEDIA_TYPE
+        );
+        let bytes = response.into_body().collect().await.unwrap().to_bytes();
+        assert_eq!(
+            decode_blob_pack(&bytes),
+            vec![
+                (second, second_bytes.to_vec()),
+                (first, first_bytes.to_vec())
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn blob_packs_do_not_disclose_other_namespaces() {
+        let (app, _directory) = test_app().await;
+        let stored = upload_blob(&app, b"private cached output").await;
+        let body = serde_json::to_vec(&serde_json::json!({"digests":[stored]})).unwrap();
+        let mut request = request("POST", "/v1/blobs:pack".into(), Body::from(body));
+        request.headers_mut().insert(
+            "mise-cache-namespace",
+            header::HeaderValue::from_static("other/project"),
+        );
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = response.into_body().collect().await.unwrap().to_bytes();
+        assert_eq!(bytes.as_ref(), BLOB_PACK_MAGIC);
+    }
+
+    #[tokio::test]
+    async fn rejects_blob_packs_over_the_configured_limit() {
+        let (app, _directory) = test_app().await;
+        let oversized = Digest {
+            algorithm: Algorithm::Blake3,
+            hash: "0".repeat(64),
+            size: 1024 * 1024 + 1,
+        };
+        let body = serde_json::to_vec(&serde_json::json!({"digests":[oversized]})).unwrap();
+        let response = app
+            .oneshot(request("POST", "/v1/blobs:pack".into(), Body::from(body)))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+    }
+
+    #[tokio::test]
     async fn publishes_action_result_only_after_references_exist() {
         let (app, _directory) = test_app().await;
         let action = upload_blob(&app, &task_action(1)).await;
@@ -1092,6 +1285,8 @@ mod tests {
         assert_eq!(body["action_kinds"]["task"]["metadata_schema"], 1);
         assert_eq!(body["action_kinds"]["rustc"]["action_schema"], 1);
         assert_eq!(body["action_kinds"]["rustc"]["metadata_schema"], 1);
+        assert_eq!(body["features"]["blob_packs"], true);
+        assert_eq!(body["limits"]["max_pack_bytes"], 1024 * 1024);
         assert!(body["features"].get("signed_results").is_none());
     }
 


### PR DESCRIPTION
## Summary

- add an optional v1 blob-pack endpoint that streams many requested CAS blobs over one response
- preserve request order, omit missing or unauthorized blobs, deduplicate requests, and enforce configured size limits
- batch namespace visibility checks in PostgreSQL and reuse that path for missing-blob queries
- prefetch up to 16 object-store reads without buffering the complete pack in memory

## Why

The latest aube qualification restored 382 blobs (910.6 MiB) through mise's remote cache. Materialization improvements cut Cargo time from 2m40s to 1m48s, but GitHub's single cache archive still completed Cargo in about 46s. The remaining dominant cost is issuing and servicing hundreds of individual blob requests.

This is the server prerequisite for a mise client follow-up that can negotiate `features.blob_packs`, group predicted artifact blobs into bounded requests, and measure the transfer improvement against both individual remote fetches and volume-backed local CAS.

## Protocol

This remains protocol v1. Servers advertise the optional `features.blob_packs` capability. The response uses a compact, self-delimiting identity framing (`MISEPK01`, algorithm, raw digest, size, bytes), and clients remain responsible for verifying every blob before admitting it to local CAS.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` (25 passed)
- Docker Compose integration against PostgreSQL and MinIO, including ordered transfer, missing-blob omission, deduplication, and capability negotiation

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*
