### PR TITLE
feat(metrics): instrument blob pack transfers

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -28,6 +28,7 @@ jobs:
       - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
+          build-args: MISE_CACHE_BUILD_REVISION=${{ github.sha }}
           push: false
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,6 +87,7 @@ jobs:
         id: push
         with:
           context: .
+          build-args: MISE_CACHE_BUILD_REVISION=${{ needs.prepare.outputs.sha }}
           push: true
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1024,6 +1024,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "dtoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590"
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1845,6 +1851,7 @@ dependencies = [
  "http 1.5.0",
  "http-body-util",
  "jsonwebtoken",
+ "prometheus-client",
  "reqwest",
  "rsa",
  "serde",
@@ -2085,6 +2092,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prometheus-client"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba70bf887030e45213b4a95c9b08d5a450b157f87c1d63661ed0847a12fa2aad"
+dependencies = [
+ "dtoa",
+ "itoa",
+ "parking_lot",
+ "prometheus-client-derive-encode",
+]
+
+[[package]]
+name = "prometheus-client-derive-encode"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9adf1691c04c0a5ff46ff8f262b58beb07b0dbb61f96f9f54f6cbd82106ed87f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ futures-util = "0.3"
 hex = "0.4"
 http = "1"
 jsonwebtoken = "9"
+prometheus-client = "0.25"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
 FROM rust:1.97-bookworm AS builder
+ARG MISE_CACHE_BUILD_REVISION=unknown
+ENV MISE_CACHE_BUILD_REVISION=$MISE_CACHE_BUILD_REVISION
 WORKDIR /src
 COPY Cargo.toml Cargo.lock ./
 COPY migrations ./migrations

--- a/README.md
+++ b/README.md
@@ -178,6 +178,18 @@ Servers advertising `features.blob_packs` accept the same digest-list JSON as `b
 
 Run multiple stateless replicas against the same PostgreSQL database and S3 bucket. Readiness and liveness probes use `/v1/status`. Scrape `/metrics` with Prometheus.
 
+The OpenMetrics endpoint exposes the existing action and blob counters plus detailed blob-pack telemetry:
+
+- accepted pack streams by `completed`, `cancelled`, or `error` outcome
+- in-flight packs and unique requested, missing, and fully served blob counts
+- requested payload bytes and payload bytes actually streamed
+- end-to-end response-body duration and time to first byte
+- namespace visibility-query duration
+- blob-store GET count and response-header latency by `hit`, `missing`, or `error` outcome
+- the running package version and build revision
+
+These metrics intentionally use only fixed, low-cardinality labels. Namespaces, repositories, tokens, OIDC claims, and content digests are never exposed as metric labels. Pack duration includes client backpressure through completion of the response body; time to first byte and blob-store response-header latency separate request setup from streaming time.
+
 Do not expire S3 objects independently of PostgreSQL metadata. The metadata store currently assumes a registered blob remains present, so independent object expiration can leave action results pointing at missing blobs. Until coordinated garbage collection is implemented, monitor storage growth and reset the blob and metadata stores together when reclaiming space.
 
 Back up PostgreSQL and enable S3 versioning or replication as required. The service never exposes a deletion endpoint, so retention and disaster recovery remain administrative concerns.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod auth;
 mod config;
 mod metadata;
+mod metrics;
 mod model;
 mod server;
 mod storage;

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,0 +1,298 @@
+use prometheus_client::{
+    encoding::{EncodeLabelSet, text::encode},
+    metrics::{counter::Counter, family::Family, gauge::Gauge, histogram::Histogram, info::Info},
+    registry::Registry,
+};
+use std::{sync::Arc, time::Duration, time::Instant};
+
+type HistogramFamily = Family<OutcomeLabels, Histogram, fn() -> Histogram>;
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+struct BuildLabels {
+    version: &'static str,
+    revision: &'static str,
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+struct KindLabels {
+    kind: &'static str,
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+struct OutcomeLabels {
+    outcome: &'static str,
+}
+
+pub struct Metrics {
+    registry: Registry,
+    blob_hits: Counter,
+    blob_uploads: Counter,
+    action_hits: Counter,
+    action_misses: Counter,
+    action_commits: Counter,
+    pack_requests: Family<OutcomeLabels, Counter>,
+    pack_in_flight: Gauge,
+    pack_blobs: Family<KindLabels, Counter>,
+    pack_bytes: Family<KindLabels, Counter>,
+    pack_duration: HistogramFamily,
+    pack_time_to_first_byte: Histogram,
+    pack_metadata_query_duration: HistogramFamily,
+    pack_storage_gets: Family<OutcomeLabels, Counter>,
+    pack_storage_get_duration: HistogramFamily,
+}
+
+impl Metrics {
+    pub fn new() -> Self {
+        let mut registry = Registry::with_prefix("mise_cache");
+        registry.register(
+            "build",
+            "Build information for the running mise-cache process",
+            Info::new(BuildLabels {
+                version: env!("CARGO_PKG_VERSION"),
+                revision: option_env!("MISE_CACHE_BUILD_REVISION").unwrap_or("unknown"),
+            }),
+        );
+
+        let blob_hits = Counter::default();
+        registry.register(
+            "blob_hits",
+            "Blob reads served by single or packed transfers",
+            blob_hits.clone(),
+        );
+        let blob_uploads = Counter::default();
+        registry.register(
+            "blob_uploads",
+            "Blob uploads accepted by the service",
+            blob_uploads.clone(),
+        );
+        let action_hits = Counter::default();
+        registry.register(
+            "action_hits",
+            "Action-result lookups that found a result",
+            action_hits.clone(),
+        );
+        let action_misses = Counter::default();
+        registry.register(
+            "action_misses",
+            "Action-result lookups that did not find a result",
+            action_misses.clone(),
+        );
+        let action_commits = Counter::default();
+        registry.register(
+            "action_commits",
+            "Action-result commit attempts",
+            action_commits.clone(),
+        );
+
+        let pack_requests = Family::default();
+        registry.register(
+            "pack_requests",
+            "Accepted blob-pack response streams by terminal outcome",
+            pack_requests.clone(),
+        );
+        let pack_in_flight = Gauge::default();
+        registry.register(
+            "pack_in_flight",
+            "Blob-pack response streams currently in flight",
+            pack_in_flight.clone(),
+        );
+        let pack_blobs = Family::default();
+        registry.register(
+            "pack_blobs",
+            "Unique blobs requested, served, or missing in blob packs",
+            pack_blobs.clone(),
+        );
+        let pack_bytes = Family::default();
+        registry.register(
+            "pack_bytes",
+            "Declared blob bytes requested or payload bytes served in blob packs",
+            pack_bytes.clone(),
+        );
+        let pack_duration = histogram_family();
+        registry.register(
+            "pack_duration_seconds",
+            "Blob-pack request duration through response-body completion",
+            pack_duration.clone(),
+        );
+        let pack_time_to_first_byte = duration_histogram();
+        registry.register(
+            "pack_time_to_first_byte_seconds",
+            "Time from entering the blob-pack handler until its first response byte",
+            pack_time_to_first_byte.clone(),
+        );
+        let pack_metadata_query_duration = histogram_family();
+        registry.register(
+            "pack_metadata_query_duration_seconds",
+            "Namespace visibility query duration for blob packs",
+            pack_metadata_query_duration.clone(),
+        );
+        let pack_storage_gets = Family::default();
+        registry.register(
+            "pack_storage_gets",
+            "Blob-store GET attempts made for blob packs",
+            pack_storage_gets.clone(),
+        );
+        let pack_storage_get_duration = histogram_family();
+        registry.register(
+            "pack_storage_get_duration_seconds",
+            "Time to receive blob-store GET response headers for blob packs",
+            pack_storage_get_duration.clone(),
+        );
+
+        Self {
+            registry,
+            blob_hits,
+            blob_uploads,
+            action_hits,
+            action_misses,
+            action_commits,
+            pack_requests,
+            pack_in_flight,
+            pack_blobs,
+            pack_bytes,
+            pack_duration,
+            pack_time_to_first_byte,
+            pack_metadata_query_duration,
+            pack_storage_gets,
+            pack_storage_get_duration,
+        }
+    }
+
+    pub fn encode(&self) -> Result<String, std::fmt::Error> {
+        let mut buffer = String::new();
+        encode(&mut buffer, &self.registry)?;
+        Ok(buffer)
+    }
+
+    pub fn inc_blob_hit(&self) {
+        self.blob_hits.inc();
+    }
+
+    pub fn inc_blob_upload(&self) {
+        self.blob_uploads.inc();
+    }
+
+    pub fn inc_action_hit(&self) {
+        self.action_hits.inc();
+    }
+
+    pub fn inc_action_miss(&self) {
+        self.action_misses.inc();
+    }
+
+    pub fn inc_action_commit(&self) {
+        self.action_commits.inc();
+    }
+
+    pub fn observe_pack_metadata_query(&self, outcome: &'static str, duration: Duration) {
+        self.pack_metadata_query_duration
+            .get_or_create(&OutcomeLabels { outcome })
+            .observe(duration.as_secs_f64());
+    }
+
+    pub fn observe_pack_storage_get(&self, outcome: &'static str, duration: Duration) {
+        let labels = OutcomeLabels { outcome };
+        self.pack_storage_gets.get_or_create(&labels).inc();
+        self.pack_storage_get_duration
+            .get_or_create(&labels)
+            .observe(duration.as_secs_f64());
+    }
+
+    pub fn start_pack(
+        self: &Arc<Self>,
+        started: Instant,
+        requested_blobs: u64,
+        requested_bytes: u64,
+        missing_blobs: u64,
+    ) -> PackGuard {
+        self.pack_in_flight.inc();
+        self.pack_blobs
+            .get_or_create(&KindLabels { kind: "requested" })
+            .inc_by(requested_blobs);
+        self.pack_blobs
+            .get_or_create(&KindLabels { kind: "missing" })
+            .inc_by(missing_blobs);
+        self.pack_bytes
+            .get_or_create(&KindLabels { kind: "requested" })
+            .inc_by(requested_bytes);
+        PackGuard {
+            metrics: self.clone(),
+            started,
+            finished: false,
+            first_byte_recorded: false,
+        }
+    }
+}
+
+pub struct PackGuard {
+    metrics: Arc<Metrics>,
+    started: Instant,
+    finished: bool,
+    first_byte_recorded: bool,
+}
+
+impl PackGuard {
+    pub fn record_first_byte(&mut self) {
+        if !self.first_byte_recorded {
+            self.metrics
+                .pack_time_to_first_byte
+                .observe(self.started.elapsed().as_secs_f64());
+            self.first_byte_recorded = true;
+        }
+    }
+
+    pub fn add_served_bytes(&self, bytes: u64) {
+        self.metrics
+            .pack_bytes
+            .get_or_create(&KindLabels { kind: "served" })
+            .inc_by(bytes);
+    }
+
+    pub fn blob_served(&self) {
+        self.metrics
+            .pack_blobs
+            .get_or_create(&KindLabels { kind: "served" })
+            .inc();
+    }
+
+    pub fn complete(&mut self) {
+        self.finish("completed");
+    }
+
+    pub fn error(&mut self) {
+        self.finish("error");
+    }
+
+    fn finish(&mut self, outcome: &'static str) {
+        if self.finished {
+            return;
+        }
+        self.finished = true;
+        let labels = OutcomeLabels { outcome };
+        self.metrics.pack_requests.get_or_create(&labels).inc();
+        self.metrics
+            .pack_duration
+            .get_or_create(&labels)
+            .observe(self.started.elapsed().as_secs_f64());
+        self.metrics.pack_in_flight.dec();
+    }
+}
+
+impl Drop for PackGuard {
+    fn drop(&mut self) {
+        if !self.finished {
+            self.finish("cancelled");
+        }
+    }
+}
+
+fn duration_histogram() -> Histogram {
+    Histogram::new([
+        0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0,
+        120.0, 300.0,
+    ])
+}
+
+fn histogram_family() -> HistogramFamily {
+    Family::new_with_constructor(duration_histogram as fn() -> Histogram)
+}

--- a/src/server.rs
+++ b/src/server.rs
@@ -9,14 +9,7 @@ use axum::{
 use futures_util::{StreamExt, TryStreamExt, stream};
 use serde::{Deserialize, Serialize};
 use sha2::Digest as _;
-use std::{
-    collections::HashSet,
-    io,
-    sync::{
-        Arc,
-        atomic::{AtomicU64, Ordering},
-    },
-};
+use std::{collections::HashSet, io, sync::Arc, time::Instant};
 use tempfile::NamedTempFile;
 use tokio::io::AsyncWriteExt;
 use tower_http::{limit::RequestBodyLimitLayer, trace::TraceLayer};
@@ -24,6 +17,7 @@ use tower_http::{limit::RequestBodyLimitLayer, trace::TraceLayer};
 use crate::{
     auth::{Access, Authorizer},
     metadata::{CommitOutcome, ManifestCommitOutcome, MetadataStore},
+    metrics::Metrics,
     model::{
         ActionResult, Algorithm, Digest, Directory, RustcAction, RustcMetadata, TaskAction,
         TaskActionManifest, TaskMetadata,
@@ -58,7 +52,7 @@ impl AppState {
             metadata,
             auth,
             max_blob_bytes,
-            metrics: Arc::new(Metrics::default()),
+            metrics: Arc::new(Metrics::new()),
         }
     }
 }
@@ -127,7 +121,7 @@ async fn get_blob(
         .await
         .map_err(ApiError::internal)?
         .ok_or_else(|| ApiError::not_found("blob not found"))?;
-    state.metrics.blob_hits.fetch_add(1, Ordering::Relaxed);
+    state.metrics.inc_blob_hit();
     Response::builder()
         .status(StatusCode::OK)
         .header(header::CONTENT_LENGTH, blob.size)
@@ -199,7 +193,7 @@ async fn put_blob(
         .register_blob(&namespace, &digest)
         .await
         .map_err(ApiError::internal)?;
-    state.metrics.blob_uploads.fetch_add(1, Ordering::Relaxed);
+    state.metrics.inc_blob_upload();
     Ok(match outcome {
         PutOutcome::Created => StatusCode::CREATED,
         PutOutcome::AlreadyExists => StatusCode::NO_CONTENT,
@@ -251,6 +245,7 @@ async fn pack_blobs(
     headers: HeaderMap,
     Json(request): Json<MissingRequest>,
 ) -> Result<Response, ApiError> {
+    let request_started = Instant::now();
     let namespace = state.auth.authorize(&headers, Access::Read).await?;
     if request.digests.len() > MAX_BATCH_ITEMS {
         return Err(ApiError::bad_request("at most 10000 digests may be packed"));
@@ -272,11 +267,28 @@ async fn pack_blobs(
             requested.push(digest);
         }
     }
-    let visible = state
-        .metadata
-        .visible_blobs(&namespace, &requested)
-        .await
-        .map_err(ApiError::internal)?;
+    let metadata_started = Instant::now();
+    let visible = match state.metadata.visible_blobs(&namespace, &requested).await {
+        Ok(visible) => {
+            state
+                .metrics
+                .observe_pack_metadata_query("success", metadata_started.elapsed());
+            visible
+        }
+        Err(error) => {
+            state
+                .metrics
+                .observe_pack_metadata_query("error", metadata_started.elapsed());
+            return Err(ApiError::internal(error));
+        }
+    };
+    let missing_blobs = requested.len().saturating_sub(visible.len()) as u64;
+    let mut pack_guard = state.metrics.start_pack(
+        request_started,
+        requested.len() as u64,
+        total_bytes,
+        missing_blobs,
+    );
     let mut entries = Vec::with_capacity(visible.len());
     for digest in visible {
         entries.push((pack_blob_header(&digest)?, digest));
@@ -284,15 +296,27 @@ async fn pack_blobs(
     let store = state.blobs.clone();
     let metrics = state.metrics.clone();
     let response_stream = async_stream::try_stream! {
+        pack_guard.record_first_byte();
         yield Bytes::from_static(BLOB_PACK_MAGIC);
         let reads = stream::iter(entries.into_iter().map(|(header, digest)| {
             let store = store.clone();
+            let metrics = metrics.clone();
             async move {
-                let blob = store
-                    .get(&digest)
-                    .await
-                    .map_err(io::Error::other)?
-                    .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "visible blob is missing from storage"))?;
+                let started = Instant::now();
+                let blob = match store.get(&digest).await {
+                    Ok(Some(blob)) => {
+                        metrics.observe_pack_storage_get("hit", started.elapsed());
+                        blob
+                    }
+                    Ok(None) => {
+                        metrics.observe_pack_storage_get("missing", started.elapsed());
+                        return Err(io::Error::new(io::ErrorKind::NotFound, "visible blob is missing from storage"));
+                    }
+                    Err(error) => {
+                        metrics.observe_pack_storage_get("error", started.elapsed());
+                        return Err(io::Error::other(error));
+                    }
+                };
                 if blob.size != digest.size {
                     return Err(io::Error::new(io::ErrorKind::InvalidData, "stored blob size does not match its digest"));
                 }
@@ -301,13 +325,21 @@ async fn pack_blobs(
         }));
         let mut reads = reads.buffered(MAX_PACK_STORAGE_READS);
         while let Some(entry) = reads.next().await {
-            let (header, mut blob) = entry?;
+            let (header, mut blob) = entry.inspect_err(|_| {
+                pack_guard.error();
+            })?;
             yield header;
             while let Some(chunk) = blob.stream.next().await {
-                yield chunk?;
+                let chunk = chunk.inspect_err(|_| {
+                    pack_guard.error();
+                })?;
+                pack_guard.add_served_bytes(chunk.len() as u64);
+                yield chunk;
             }
-            metrics.blob_hits.fetch_add(1, Ordering::Relaxed);
+            pack_guard.blob_served();
+            metrics.inc_blob_hit();
         }
+        pack_guard.complete();
     }
     .map_err(|error: io::Error| error);
     Response::builder()
@@ -346,11 +378,11 @@ async fn get_action_result(
         .map_err(ApiError::internal)?
     {
         Some(result) => {
-            state.metrics.action_hits.fetch_add(1, Ordering::Relaxed);
+            state.metrics.inc_action_hit();
             Ok(Json(result))
         }
         None => {
-            state.metrics.action_misses.fetch_add(1, Ordering::Relaxed);
+            state.metrics.inc_action_miss();
             Err(ApiError::not_found("action result not found"))
         }
     }
@@ -383,7 +415,7 @@ async fn put_action_result(
         .commit(&namespace, &action, &result)
         .await
         .map_err(ApiError::internal)?;
-    state.metrics.action_commits.fetch_add(1, Ordering::Relaxed);
+    state.metrics.inc_action_commit();
     match outcome {
         CommitOutcome::Created => Ok(StatusCode::CREATED),
         CommitOutcome::AlreadyExists => Ok(StatusCode::NO_CONTENT),
@@ -792,21 +824,16 @@ fn validate_entry(names: &mut HashSet<String>, name: &str, mode: u32) -> Result<
     Ok(())
 }
 
-async fn metrics(State(state): State<AppState>) -> String {
-    format!(
-        concat!(
-            "# TYPE mise_cache_blob_hits_total counter\nmise_cache_blob_hits_total {}\n",
-            "# TYPE mise_cache_blob_uploads_total counter\nmise_cache_blob_uploads_total {}\n",
-            "# TYPE mise_cache_action_hits_total counter\nmise_cache_action_hits_total {}\n",
-            "# TYPE mise_cache_action_misses_total counter\nmise_cache_action_misses_total {}\n",
-            "# TYPE mise_cache_action_commits_total counter\nmise_cache_action_commits_total {}\n"
-        ),
-        state.metrics.blob_hits.load(Ordering::Relaxed),
-        state.metrics.blob_uploads.load(Ordering::Relaxed),
-        state.metrics.action_hits.load(Ordering::Relaxed),
-        state.metrics.action_misses.load(Ordering::Relaxed),
-        state.metrics.action_commits.load(Ordering::Relaxed)
-    )
+async fn metrics(State(state): State<AppState>) -> Result<Response, ApiError> {
+    let body = state.metrics.encode().map_err(ApiError::internal)?;
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(
+            header::CONTENT_TYPE,
+            "application/openmetrics-text; version=1.0.0; charset=utf-8",
+        )
+        .body(Body::from(body))
+        .map_err(ApiError::internal)
 }
 
 fn parse_digest((algorithm, hash, size): (String, String, u64)) -> Result<Digest, ApiError> {
@@ -877,15 +904,6 @@ fn manifest_precondition(headers: &HeaderMap) -> Result<Option<String>, ApiError
 
 fn quoted_etag(etag: &str) -> String {
     format!("\"{etag}\"")
-}
-
-#[derive(Default)]
-struct Metrics {
-    blob_hits: AtomicU64,
-    blob_uploads: AtomicU64,
-    action_hits: AtomicU64,
-    action_misses: AtomicU64,
-    action_commits: AtomicU64,
 }
 
 pub struct ApiError {
@@ -1142,6 +1160,18 @@ mod tests {
         digest
     }
 
+    async fn scrape_metrics(app: &Router) -> (HeaderMap, String) {
+        let response = app
+            .clone()
+            .oneshot(request("GET", "/metrics".into(), Body::empty()))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let headers = response.headers().clone();
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        (headers, String::from_utf8(body.to_vec()).unwrap())
+    }
+
     #[tokio::test]
     async fn streams_and_validates_blobs() {
         let (app, _directory) = test_app().await;
@@ -1198,6 +1228,79 @@ mod tests {
                 (first, first_bytes.to_vec())
             ]
         );
+    }
+
+    #[tokio::test]
+    async fn exports_completed_blob_pack_metrics() {
+        let (app, _directory) = test_app().await;
+        let stored = upload_blob(&app, b"cached output").await;
+        let missing = digest(b"missing output");
+        let requested_bytes = stored.size + missing.size;
+        let body = serde_json::to_vec(&serde_json::json!({
+            "digests":[stored.clone(), missing]
+        }))
+        .unwrap();
+        let response = app
+            .clone()
+            .oneshot(request("POST", "/v1/blobs:pack".into(), Body::from(body)))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        response.into_body().collect().await.unwrap();
+
+        let (headers, metrics) = scrape_metrics(&app).await;
+        assert_eq!(
+            headers.get(header::CONTENT_TYPE).unwrap(),
+            "application/openmetrics-text; version=1.0.0; charset=utf-8"
+        );
+        assert!(metrics.contains("mise_cache_build_info{"));
+        assert!(metrics.contains("mise_cache_blob_hits_total 1"));
+        assert!(metrics.contains("mise_cache_blob_uploads_total 1"));
+        assert!(metrics.contains("mise_cache_pack_requests_total{outcome=\"completed\"} 1"));
+        assert!(metrics.contains("mise_cache_pack_in_flight 0"));
+        assert!(metrics.contains("mise_cache_pack_blobs_total{kind=\"requested\"} 2"));
+        assert!(metrics.contains("mise_cache_pack_blobs_total{kind=\"served\"} 1"));
+        assert!(metrics.contains("mise_cache_pack_blobs_total{kind=\"missing\"} 1"));
+        assert!(metrics.contains(&format!(
+            "mise_cache_pack_bytes_total{{kind=\"requested\"}} {requested_bytes}"
+        )));
+        assert!(metrics.contains(&format!(
+            "mise_cache_pack_bytes_total{{kind=\"served\"}} {}",
+            stored.size
+        )));
+        assert!(
+            metrics.contains("mise_cache_pack_duration_seconds_count{outcome=\"completed\"} 1")
+        );
+        assert!(metrics.contains("mise_cache_pack_time_to_first_byte_seconds_count 1"));
+        assert!(metrics.contains(
+            "mise_cache_pack_metadata_query_duration_seconds_count{outcome=\"success\"} 1"
+        ));
+        assert!(metrics.contains("mise_cache_pack_storage_gets_total{outcome=\"hit\"} 1"));
+        assert!(
+            metrics
+                .contains("mise_cache_pack_storage_get_duration_seconds_count{outcome=\"hit\"} 1")
+        );
+    }
+
+    #[tokio::test]
+    async fn records_cancelled_blob_pack_streams() {
+        let (app, _directory) = test_app().await;
+        let stored = upload_blob(&app, b"cached output").await;
+        let body = serde_json::to_vec(&serde_json::json!({"digests":[stored]})).unwrap();
+        let response = app
+            .clone()
+            .oneshot(request("POST", "/v1/blobs:pack".into(), Body::from(body)))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        drop(response);
+
+        let (_, metrics) = scrape_metrics(&app).await;
+        assert!(metrics.contains("mise_cache_pack_requests_total{outcome=\"cancelled\"} 1"));
+        assert!(
+            metrics.contains("mise_cache_pack_duration_seconds_count{outcome=\"cancelled\"} 1")
+        );
+        assert!(metrics.contains("mise_cache_pack_in_flight 0"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- replace the hand-written metrics response with a typed OpenMetrics registry while preserving the existing counter names
- instrument accepted blob-pack streams through body completion, cancellation, or error
- expose requested, missing, and fully served blob counts; requested and produced payload bytes; in-flight work; end-to-end duration; and time to first byte
- separate namespace visibility-query latency from blob-store GET response-header latency and outcomes
- embed the package version and exact container source revision in build information

## Why

The blob-pack client and benchmark harness need enough evidence to explain performance rather than only compare wall-clock totals. Axum handlers return before streaming bodies finish, so normal request middleware cannot distinguish a completed transfer from client cancellation or measure the full pack duration. A response-body guard now records the actual terminal outcome and duration.

All labels are fixed and low-cardinality. Metrics never expose namespaces, repositories, tokens, OIDC claims, or content digests.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features` (27 passed)
- Docker Compose integration against PostgreSQL and MinIO, including a completed mixed hit/miss pack and live OpenMetrics scrape
- production and PR container build paths pass the source revision as a build argument

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*
