### PR TITLE
fix(deploy): unbreak the production deploy after the rebrand

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,30 @@ jobs:
           install -m 0600 cache.env.example cache.env
           docker compose --env-file runtime.env.example config --quiet
           jq empty monitoring/grafana/dashboards/mbx-cache.json
+      - name: Validate the Helm chart
+        run: |
+          base=(--set config.databaseUrl=postgres://cache/cache --set config.s3Bucket=cache)
+          helm lint charts/mbx-cache "${base[@]}"
+
+          # The deployment must never name a ServiceAccount the chart did not
+          # create, or its pods stay unschedulable.
+          created() { awk '/^kind: ServiceAccount$/{f=1;next} f&&/^  name: /{print $2;exit}'; }
+          referenced() { awk '/serviceAccountName: /{print $2;exit}'; }
+          check() {
+            want_created=$1 want_referenced=$2
+            shift 2
+            rendered=$(helm template test charts/mbx-cache "${base[@]}" "$@")
+            got_created=$(printf '%s' "$rendered" | created)
+            got_referenced=$(printf '%s' "$rendered" | referenced)
+            if [[ "${got_created:-none}" != "$want_created" || "$got_referenced" != "$want_referenced" ]]; then
+              echo "::error::helm $*: created=${got_created:-none} (want $want_created), referenced=$got_referenced (want $want_referenced)"
+              exit 1
+            fi
+          }
+          check test-mbx-cache test-mbx-cache
+          check custom custom --set serviceAccount.name=custom
+          check none existing --set serviceAccount.create=false --set serviceAccount.name=existing
+          check none default --set serviceAccount.create=false
       - run: shellcheck deploy/ovh/deploy.sh deploy/ovh/test-deploy.sh
       - run: deploy/ovh/test-deploy.sh
   test:

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -82,7 +82,9 @@ jobs:
     env:
       CACHE_URL: https://cache.mise.jdx.dev
       CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID || secrets.CLOUDFLARE_ACCOUNT_ID }}
-      MBX_CACHE_DATABASE_PASSWORD: ${{ secrets.MBX_CACHE_DATABASE_PASSWORD }}
+      # The stored secret keeps its original name; it cannot easily be
+      # recreated, so the rebrand deliberately did not rename it.
+      MBX_CACHE_DATABASE_PASSWORD: ${{ secrets.MISE_CACHE_DATABASE_PASSWORD }}
       R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
       R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
       TS_AUDIENCE: ${{ secrets.TS_AUDIENCE }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1792,7 +1792,7 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "mbx-cache"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbx-cache"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2024"
 license = "MIT"
 description = "Self-hosted remote build cache server for mbx"

--- a/charts/mbx-cache/templates/_helpers.tpl
+++ b/charts/mbx-cache/templates/_helpers.tpl
@@ -1,0 +1,21 @@
+{{/*
+Resource name for this release.
+*/}}
+{{- define "mbx-cache.fullname" -}}
+{{- printf "%s-mbx-cache" .Release.Name -}}
+{{- end -}}
+
+{{/*
+ServiceAccount the pods run as.
+
+When the chart does not create one, fall back to the namespace's `default`
+rather than the generated name: referencing a ServiceAccount that nothing
+created leaves the pods unschedulable.
+*/}}
+{{- define "mbx-cache.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "mbx-cache.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}

--- a/charts/mbx-cache/templates/deployment.yaml
+++ b/charts/mbx-cache/templates/deployment.yaml
@@ -11,7 +11,7 @@ spec:
       labels: {app.kubernetes.io/name: mbx-cache, app.kubernetes.io/instance: {{ .Release.Name }}}
       annotations: {{ toYaml .Values.podAnnotations | nindent 8 }}
     spec:
-      serviceAccountName: {{ default (printf "%s-mbx-cache" .Release.Name) .Values.serviceAccount.name }}
+      serviceAccountName: {{ include "mbx-cache.serviceAccountName" . }}
       securityContext: {runAsNonRoot: true, seccompProfile: {type: RuntimeDefault}}
       containers:
         - name: mbx-cache

--- a/charts/mbx-cache/templates/serviceaccount.yaml
+++ b/charts/mbx-cache/templates/serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ default (printf "%s-mbx-cache" .Release.Name) .Values.serviceAccount.name }}
+  name: {{ include "mbx-cache.serviceAccountName" . }}
   labels: {app.kubernetes.io/name: mbx-cache, app.kubernetes.io/instance: {{ .Release.Name }}}
 {{- end }}
 

--- a/deploy/ovh/README.md
+++ b/deploy/ovh/README.md
@@ -43,7 +43,7 @@ and plan availability before applying the configuration.
 - a current OVH US VPS plan code and Ubuntu image ID only when ordering a VPS
 - an existing R2 bucket and Object Read & Write token restricted to that bucket
 - a DNS-only Cloudflare A record for the public cache hostname
-- a published, immutable mbx-cache image tag or digest
+- a published mbx-cache image digest (`…@sha256:<64 hex>`; `deploy.sh` rejects a tag)
 
 Set `TERRAFORM_COMMAND=tofu` when using OpenTofu for the deploy step.
 
@@ -149,8 +149,11 @@ local project on success or failure. The caller's other environment variables
 are never forwarded.
 
 Automated deployments store `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, and
-`MBX_CACHE_DATABASE_PASSWORD` in the repository's protected `production`
-GitHub Environment. Environment protection keeps these values out of ordinary
+the database password in the repository's protected `production` GitHub
+Environment. That last secret is still named `MISE_CACHE_DATABASE_PASSWORD`:
+it cannot easily be recreated, so the rebrand left it alone and the workflow
+maps it onto `MBX_CACHE_DATABASE_PASSWORD`. Renaming the reference without
+renaming the secret is what broke the first deploy after the rebrand. Environment protection keeps these values out of ordinary
 pull-request jobs. The R2 credential remains limited by its Cloudflare bucket
 policy even if a workflow is compromised. Use a local password manager to
 populate the same variables for an emergency operator-run deployment; never


### PR DESCRIPTION
Fixes the two jobs that failed after #26 merged, plus the chart bug that review turned up. Both failures were caused by the rebrand, and both failed closed — production is untouched and still serving the previous image.

## The deploy secret

`Deploy production` failed with `Missing production configuration: MBX_CACHE_DATABASE_PASSWORD`. The rebrand renamed the *reference* in `release-plz.yml`, but the secret stored in the `production` environment still has its original name, so it resolved empty and `deploy.sh`'s validation refused to continue. It was the only brand-prefixed secret in the repo — `RELEASE_PLZ_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`, `R2_*`, and `TS_*` were never prefixed, which is why nothing else broke.

Since the stored secret cannot easily be recreated, the workflow reads `secrets.MISE_CACHE_DATABASE_PASSWORD` again, permanently. The environment variable handed to `deploy.sh` keeps the new name, so nothing downstream changes. There is a comment at the reference and a note in `deploy/ovh/README.md` recording the exception, because renaming this reference without renaming the secret is precisely what broke the deploy.

## The release-plz deadlock

`Release PR` failed with:

> local package `mbx-cache` has a greater version (0.1.1) with respect to the registry package (0.0.0), but the git tag v0.1.1 exists

Three things collided: the crate still carried `mise-cache`'s 0.1.1, crates.io has only the 0.0.0 placeholder reserved during the rename, and tag `v0.1.1` already existed. Bumping to 0.2.0 clears all three without a manual `cargo publish` — it is ahead of both versions, no `v0.2.0` tag exists, and a minor bump on a 0.x crate is an honest signal for the rename. The alternative was publishing 0.1.1 by hand, which I have not done because publishing is your call.

## The chart bug

With `serviceAccount.create: false` and the shipped `name: ""` default, `serviceaccount.yaml` rendered nothing while `deployment.yaml` still asked for `<release>-mbx-cache`. Kubernetes refuses to create pods naming a ServiceAccount that does not exist, so the release would install and never become ready — the bring-your-own-ServiceAccount path only worked if you also remembered to set `name`. The cause was duplication: both templates repeated the same expression, which cannot express the `create: false` case at all.

Both now resolve the name through `mbx-cache.serviceAccountName` in a new `_helpers.tpl`, using the standard Helm semantics of falling back to the namespace `default`. Predates the rebrand; unrelated to it.

## Why nothing caught any of this

The `deployment` job validates terraform, the bootstrap plan, compose config, the dashboard JSON, and shellcheck — but never rendered the chart. It now runs `helm lint` and asserts all four combinations:

| `create` | `name` | ServiceAccount rendered | `serviceAccountName` |
| --- | --- | --- | --- |
| true | `""` | `<release>-mbx-cache` | `<release>-mbx-cache` |
| true | `custom` | `custom` | `custom` |
| false | `existing` | none | `existing` |
| false | `""` | none | `default` |

`ubuntu-latest` already ships Helm 3.21.3, so this needs no new action. I verified the step by extracting it and running it verbatim: it passes on this branch, and reverting just the deployment template makes it fail on the fourth row alone, so the assertion bites without over-matching. Rows one to three render exactly as they do today, making this a fix for the broken case and a no-op for working deployments.

29 tests pass, clippy is clean with `-D warnings`, and shellcheck is clean.

**After merge**, the `Deploy production` job needs a re-run to actually roll out; the container images from #26 published fine, so there is nothing else to rebuild. Worth remembering from #26 that the first successful deploy comes up against a fresh PostgreSQL volume and role, so the cache starts cold.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches production deploy secrets and Helm pod identity. The secret mapping is a one-line restore of the pre-rebrand name; the chart change only affects the previously broken create=false path.
> 
> **Overview**
> Unbreaks production deploy and release-plz after the rebrand, and fixes Helm ServiceAccount naming so pods stay schedulable.
> 
> The production workflow now maps `secrets.MISE_CACHE_DATABASE_PASSWORD` onto `MBX_CACHE_DATABASE_PASSWORD` (the stored secret was never renamed). The crate version bumps from `0.1.1` to `0.2.0` so release-plz is no longer stuck against crates.io `0.0.0` and the existing `v0.1.1` tag.
> 
> The chart resolves ServiceAccount names through `mbx-cache.serviceAccountName`: when `create` is false it uses an explicit name or `default` instead of a generated name that was never created. CI now lints the chart and asserts all four create/name combinations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d12893187107a4dae515234704bf8a3a54dff9c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Helm deployments now support chart-created, custom, or existing service accounts.
  - Deployment validation covers multiple service-account configurations.

- **Bug Fixes**
  - Improved service-account selection prevents workloads from referencing unavailable accounts.
  - Production deployments now use the correct protected database password secret.

- **Documentation**
  - Deployment requirements now specify immutable container image digests and updated database credential configuration.

- **Chores**
  - Updated the package version to 0.2.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->