### PR TITLE
fix(deploy): point the deploy back at the infrastructure that exists

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -128,20 +128,24 @@ jobs:
           install: false
           cache: false
 
+      # The tailnet tag and the host's MagicDNS name are pre-rebrand identifiers
+      # that live in Tailscale, not in this repository. See "Names that predate
+      # the rebrand" in deploy/ovh/README.md before changing either.
       - name: Join the deployment tailnet
         uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8 # v4.1.3
         with:
           oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
           audience: ${{ secrets.TS_AUDIENCE }}
-          tags: tag:mbx-cache-ci
-          ping: mbx-cache-prod.tail13c301.ts.net
+          tags: tag:mise-cache-ci
+          ping: mise-cache-prod.tail13c301.ts.net
 
       - name: Configure deployment outputs
         env:
           TF_VAR_cloudflare_account_id: ${{ env.CLOUDFLARE_ACCOUNT_ID }}
           TF_VAR_domain: cache.mise.jdx.dev
           TF_VAR_existing_server_ipv4: 15.204.81.200
-          TF_VAR_r2_bucket: mbx-cache-production
+          # Existing bucket; the R2 token is scoped to this exact name.
+          TF_VAR_r2_bucket: mise-cache-production
         run: |
           terraform -chdir=deploy/ovh/terraform init -backend=false -input=false
           terraform -chdir=deploy/ovh/terraform apply -auto-approve -input=false
@@ -150,7 +154,7 @@ jobs:
         env:
           MBX_CACHE_DEPLOY_GITHUB_WORKFLOW_REF: jdx/mbx-cache/.github/workflows/release-plz.yml@refs/heads/main
           MBX_CACHE_IMAGE: ${{ format('ghcr.io/jdx/mbx-cache@{0}', needs.image.outputs.digest) }}
-          OVH_SSH_HOST: mbx-cache-prod.tail13c301.ts.net
+          OVH_SSH_HOST: mise-cache-prod.tail13c301.ts.net
         run: |
           OVH_SSH_SOURCE_CIDR="$(tailscale ip -4)/32"
           export OVH_SSH_SOURCE_CIDR

--- a/deploy/ovh/README.md
+++ b/deploy/ovh/README.md
@@ -104,7 +104,7 @@ no managed infrastructure resources.
 
 ## Create R2 storage and DNS
 
-Create the `mbx-cache-production` R2 bucket with Standard storage in Eastern
+Create the `mise-cache-production` R2 bucket with Standard storage in Eastern
 North America, then create an R2 API token with Object Read & Write permission
 scoped only to that bucket. Save its Access Key ID and Secret Access Key;
 Cloudflare displays the secret only once.
@@ -124,7 +124,7 @@ export MBX_CACHE_IMAGE=ghcr.io/jdx/mbx-cache@sha256:<64-hex-digit-digest>
 export MBX_CACHE_DATABASE_PASSWORD="$(openssl rand -hex 24)"
 export R2_ACCESS_KEY_ID=...
 export R2_SECRET_ACCESS_KEY=...
-export OVH_SSH_HOST="mbx-cache-prod.example-tailnet.ts.net"
+export OVH_SSH_HOST="mise-cache-prod.example-tailnet.ts.net"
 export OVH_SSH_SOURCE_CIDR="$(tailscale ip -4)/32"
 ./deploy/ovh/deploy.sh
 ```
@@ -149,12 +149,10 @@ local project on success or failure. The caller's other environment variables
 are never forwarded.
 
 Automated deployments store `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, and
-the database password in the repository's protected `production` GitHub
-Environment. That last secret is still named `MISE_CACHE_DATABASE_PASSWORD`:
-it cannot easily be recreated, so the rebrand left it alone and the workflow
-maps it onto `MBX_CACHE_DATABASE_PASSWORD`. Renaming the reference without
-renaming the secret is what broke the first deploy after the rebrand. Environment protection keeps these values out of ordinary
-pull-request jobs. The R2 credential remains limited by its Cloudflare bucket
+`MISE_CACHE_DATABASE_PASSWORD` in the repository's protected `production` GitHub
+Environment; see "Names that predate the rebrand" below for why that last one
+keeps its original name. Environment protection keeps these values out of
+ordinary pull-request jobs. The R2 credential remains limited by its Cloudflare bucket
 policy even if a workflow is compromised. Use a local password manager to
 populate the same variables for an emergency operator-run deployment; never
 commit their plaintext values.
@@ -231,3 +229,30 @@ Do not add an R2 expiration lifecycle yet. The current metadata store does not
 garbage-collect references when objects expire, so independent R2 expiration
 can leave action results pointing at missing blobs. Monitor usage while
 coordinated metadata/blob garbage collection is implemented.
+
+## Names that predate the rebrand
+
+Renaming this project from `mise-cache` to `mbx-cache` renamed only what lives
+in this repository. Several identifiers name resources owned by Tailscale,
+Cloudflare, GitHub, and the host itself, and those keep their original names.
+Two deploys failed in a row because the repository was changed and the resource
+was not, so **do not "fix" these to match the brand** unless you rename the
+resource first.
+
+| Identifier | Where it lives | Why it stays |
+| --- | --- | --- |
+| `MISE_CACHE_DATABASE_PASSWORD` | `production` GitHub Environment secret | Cannot easily be recreated; the workflow maps it onto `MBX_CACHE_DATABASE_PASSWORD` |
+| `tag:mise-cache-ci` | Tailscale ACL policy | CI may only advertise a tag the tailnet policy defines |
+| `mise-cache-prod.tail13c301.ts.net` | The host's MagicDNS name | Renaming the machine changes the name CI pings and reaches over SSH |
+| `mise-cache-production` | Cloudflare R2 | Pre-existing bucket; the R2 token is scoped to this exact name, and the cache's stored blobs are in it |
+
+One identifier could not be preserved: GitHub's OIDC subject embeds the
+repository, so the tokens this workflow presents now say `jdx/mbx-cache`. Any
+external trust that was pinned to `jdx/mise-cache` has to be updated on that
+side — including the Tailscale trust credential used to join the tailnet, which
+is what fails if the tailnet step reports `failed to exchange JWT for access
+token`.
+
+If decoupling these from the brand becomes worthwhile, move them to repository
+variables so the values live with the infrastructure rather than in the
+workflow.

--- a/deploy/ovh/bootstrap/cache.env.example
+++ b/deploy/ovh/bootstrap/cache.env.example
@@ -1,6 +1,6 @@
 MBX_CACHE_STORAGE="s3"
 MBX_CACHE_DATABASE_URL="postgres://mbx_cache:replace-with-a-url-safe-password@postgres/mbx_cache"
-MBX_CACHE_S3_BUCKET="mbx-cache-production"
+MBX_CACHE_S3_BUCKET="mise-cache-production"
 MBX_CACHE_S3_PREFIX="v1"
 MBX_CACHE_S3_ENDPOINT="https://example.r2.cloudflarestorage.com"
 MBX_CACHE_S3_REGION="auto"

--- a/deploy/ovh/terraform/terraform.tfvars.example
+++ b/deploy/ovh/terraform/terraform.tfvars.example
@@ -1,6 +1,6 @@
 domain                  = "cache.mise.jdx.dev"
 cloudflare_account_id   = "replace-me"
-r2_bucket               = "mbx-cache-production"
+r2_bucket               = "mise-cache-production"
 # existing_server_ipv4  = "replace-with-existing-vps-ipv4"
 datacenter               = "US-EAST-VA"
 operating_system         = "Ubuntu 24.04"


### PR DESCRIPTION
The deploy is failing one step at a time because the rebrand renamed things that are not ours to rename.

`Validate deployment configuration` passes now (that was #27), and the run gets as far as `Join the deployment tailnet`, where it fails:

```
failed to exchange JWT for access token: token exchange failed with status 403:
{"message":"Unauthorized. Visit https://login.tailscale.com/admin/settings/trust-credentials/view/*** for details"}
```

Chasing that turned up three more of the same class waiting behind it. These identifiers name resources owned by Tailscale, Cloudflare, and the host — not by this repository — and none of them were renamed:

| Identifier | Where it lives | What breaks |
| --- | --- | --- |
| `tag:mbx-cache-ci` | Tailscale ACL policy | CI can only advertise a tag the policy defines |
| `mbx-cache-prod.tail13c301.ts.net` | The host's MagicDNS name | Both the tailnet `ping` and `OVH_SSH_HOST` resolve to nothing |
| `mbx-cache-production` | Cloudflare R2 | Terraform documents it as an *existing* bucket, the R2 token is scoped to that exact name, and the cache's blobs are in it |

All three go back to their original names, the same call you made for `MISE_CACHE_DATABASE_PASSWORD`. `deploy/ovh/README.md` gains a **Names that predate the rebrand** section listing all four with the reason each one stays, and the workflow carries comments pointing at it — this is the second deploy the brand rename has broken, and the failure mode is someone helpfully "fixing" the inconsistency.

Deliberately left alone: the Actions concurrency group (`mbx-cache-production`, internal to GitHub and names nothing external), the synthetic `-var` in CI's `terraform plan` validation, and `test-deploy.sh`'s fixtures — all self-contained.

## One thing this cannot fix

GitHub's OIDC subject embeds the repository name, so the tokens this workflow presents now say `jdx/mbx-cache` where they used to say `jdx/mise-cache`. Any external trust pinned to the old repository has to be updated on that side, and the Tailscale trust credential is one of them — that is what the 403 above is. **This PR does not fix the tailnet step**; it clears the three landmines that would each have failed the deploy after you do. The error message links straight to the credential.

If decoupling these from the brand is ever worth it, they could move to repository variables so the values live with the infrastructure instead of the workflow — noted in the README rather than done here, since it trades one kind of drift for another.

## Verification

- `shellcheck` clean on both deploy scripts; `deploy/ovh/test-deploy.sh` passes.
- `terraform fmt -check -recursive` clean, `terraform validate` succeeds.
- `cargo fmt --check` clean, 29 tests pass.
- Re-grepped the deploy path: no reference to a renamed resource remains.

Worth restating from #26 for whenever this does deploy: the PostgreSQL volume and role renamed, so the metadata store starts empty and the cache comes up cold. Now that the bucket name is restored, the blobs in R2 survive.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches production deploy targeting (Tailscale join, SSH host, R2 bucket). Values are restored to existing infrastructure rather than introducing new auth or data-handling logic.
> 
> **Overview**
> Restores production deploy identifiers that live outside this repo after the `mise-cache` → `mbx-cache` rebrand broke CI.
> 
> The workflow now uses `tag:mise-cache-ci`, MagicDNS `mise-cache-prod.tail13c301.ts.net`, and R2 bucket `mise-cache-production` again, matching the Tailscale ACL, host name, and token-scoped bucket. Docs and examples get the same names, plus a **Names that predate the rebrand** section so they are not “fixed” again.
> 
> This does **not** fix Tailscale OIDC trust: GitHub tokens now say `jdx/mbx-cache`, so the tailnet credential still needs an out-of-repo update. Internal-only names (concurrency group, CI terraform fixtures) stay as `mbx-cache-*`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0df3cd574d4c1f4585cb1cd0c793e707ff835d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Deployment Updates**
  * Updated cache deployment configuration to use the new `mise-cache` service identifiers.
  * Updated storage bucket and deployment host settings for production environments.
  * Preserved compatibility with legacy identifiers where required by external integrations.

* **Documentation**
  * Refreshed OVH deployment instructions and example configuration files.
  * Added guidance for environment secrets and legacy identifiers retained during the rebrand.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->