### PR TITLE
feat(metadata): record when blobs are served

### DIFF
--- a/src/metadata/mod.rs
+++ b/src/metadata/mod.rs
@@ -40,6 +40,15 @@ pub trait MetadataStore: Send + Sync {
             .is_empty())
     }
     async fn register_blob(&self, namespace: &str, digest: &Digest) -> anyhow::Result<()>;
+    /// Record that these blobs were served to a client.
+    ///
+    /// `namespace_blobs.last_accessed_at` otherwise only ever holds the time a
+    /// blob was uploaded, which would make a future garbage collector evict the
+    /// blobs a build depends on most. Recording an access is best-effort and
+    /// must never fail a read; stores without durable metadata do nothing.
+    async fn touch_blobs(&self, _namespace: &str, _digests: &[Digest]) -> anyhow::Result<()> {
+        Ok(())
+    }
     async fn get(&self, namespace: &str, action: &Digest) -> anyhow::Result<Option<ActionResult>>;
     async fn commit(
         &self,

--- a/src/metadata/postgres.rs
+++ b/src/metadata/postgres.rs
@@ -6,6 +6,9 @@ use crate::model::{ActionResult, Digest, TaskActionManifest};
 
 static MIGRATOR: sqlx::migrate::Migrator = sqlx::migrate!();
 
+/// How stale a blob's recorded access has to be before a read refreshes it.
+const ACCESS_REFRESH_INTERVAL: &str = "1 hour";
+
 pub struct PostgresMetadata {
     pool: PgPool,
 }
@@ -72,6 +75,43 @@ impl MetadataStore for PostgresMetadata {
                     .ok_or_else(|| anyhow::anyhow!("database returned an invalid blob ordinal"))
             })
             .collect()
+    }
+
+    async fn touch_blobs(&self, namespace: &str, digests: &[Digest]) -> anyhow::Result<()> {
+        let digests = representable_digests(digests);
+        if digests.is_empty() {
+            return Ok(());
+        }
+        let algorithms = digests
+            .iter()
+            .map(|(digest, _)| digest.algorithm.to_string())
+            .collect::<Vec<_>>();
+        let hashes = digests
+            .iter()
+            .map(|(digest, _)| digest.hash.clone())
+            .collect::<Vec<_>>();
+        let sizes = digests.iter().map(|(_, size)| *size).collect::<Vec<_>>();
+        // Skip blobs touched recently so a frequently served blob costs at most
+        // one write per interval rather than one per read.
+        sqlx::query(
+            "UPDATE namespace_blobs AS blobs \
+             SET last_accessed_at = now() \
+             FROM UNNEST($2::text[], $3::text[], $4::bigint[]) \
+                  AS requested(algorithm, hash, size) \
+             WHERE blobs.namespace = $1 \
+               AND blobs.algorithm = requested.algorithm \
+               AND blobs.hash = requested.hash \
+               AND blobs.size = requested.size \
+               AND blobs.last_accessed_at < now() - $5::interval",
+        )
+        .bind(namespace)
+        .bind(algorithms)
+        .bind(hashes)
+        .bind(sizes)
+        .bind(ACCESS_REFRESH_INTERVAL)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
     }
 
     async fn register_blob(&self, namespace: &str, digest: &Digest) -> anyhow::Result<()> {

--- a/src/server.rs
+++ b/src/server.rs
@@ -84,6 +84,16 @@ pub fn router(state: AppState) -> Router {
         .with_state(state)
 }
 
+/// Note a read so a future garbage collector can evict by real use.
+///
+/// Losing an access record only makes eviction slightly less well informed, so
+/// this never turns a served blob into a failed request.
+async fn record_blob_access(state: &AppState, namespace: &str, digests: &[Digest]) {
+    if let Err(error) = state.metadata.touch_blobs(namespace, digests).await {
+        tracing::debug!(%error, "could not record blob access");
+    }
+}
+
 async fn status() -> impl IntoResponse {
     Json(serde_json::json!({"status":"ok","protocol":1}))
 }
@@ -117,6 +127,7 @@ async fn get_blob(
     {
         return Err(ApiError::not_found("blob not found"));
     }
+    record_blob_access(&state, &namespace, std::slice::from_ref(&digest)).await;
     let blob = state
         .blobs
         .get(&digest)
@@ -284,6 +295,7 @@ async fn pack_blobs(
             return Err(ApiError::internal(error));
         }
     };
+    record_blob_access(&state, &namespace, &visible).await;
     let missing_blobs = requested.len().saturating_sub(visible.len()) as u64;
     let mut pack_guard = state.metrics.start_pack(
         request_started,


### PR DESCRIPTION
`namespace_blobs.last_accessed_at` has been in the schema since `0001_init.sql`, and nothing has ever read or written it. It defaults to `now()` on insert, so today it records when a blob was **uploaded**, not when it was last used.

That matters because it is the column an eviction policy would run on. A garbage collector built against it as-is would evict backwards: a dependency rlib uploaded once and served on every build since looks like the coldest object in the store, while a blob uploaded yesterday and never touched again looks hot. `deploy/ovh/README.md` already warns against adding an R2 lifecycle rule for the related reason — expiry that the metadata store knows nothing about leaves action results pointing at missing blobs.

So this starts collecting the data, ahead of the collector that will need it. Serving a blob — singly through `GET /v1/blobs/...` or in a pack through `POST /v1/blobs:pack` — refreshes the timestamp.

Two things keep it off the hot path:

- **Reads only write when the record is stale.** The `UPDATE` carries `AND blobs.last_accessed_at < now() - '1 hour'::interval`, so a blob served a thousand times an hour costs one write, not a thousand. Without that guard this would put a database write behind every cache hit.
- **A failed update never fails a read.** `record_blob_access` logs at debug and returns; losing an access record makes future eviction slightly less well informed, which is not worth turning a served blob into a 500.

`touch_blobs` is a defaulted no-op on the `MetadataStore` trait, so the in-memory store used for development keeps doing nothing — there is nothing durable there to inform.

I deliberately did not touch `visible_blobs`. It backs the batch missing-blob query and several commit-validation paths, and an existence check made while deciding whether to *upload* is not evidence that anyone wants the blob. Counting those would bias the data toward whatever a writer happened to ask about.

## Verification

There is no Postgres in CI and no existing test covers `PostgresMetadata` at all, so raw SQL here would otherwise ship unexercised. I ran it against a real PostgreSQL 17 with the repository's migrations applied:

| check | result |
| --- | --- |
| Stale row (5 days) vs fresh row (1 minute), one `UPDATE` | stale refreshed, fresh untouched |
| Real `PUT` then `GET` through the server, row backdated 3 days | `age` went from `3 days` to `00:00:01` |
| Second `GET` immediately after | `last_accessed_at` byte-identical — the guard held |
| `POST /v1/blobs:pack` with the row backdated 3 days | refreshed |

Also `cargo fmt --check` clean, clippy clean with `-D warnings`, 29 tests passing.

Worth saying plainly: that Postgres backend being untested in CI is the larger gap here. Adding a Postgres service to the test job would let checks like the four above live in the suite instead of in a PR description. I left that out to keep this change small, but it is the natural next step if garbage collection is coming.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a Postgres UPDATE on the blob read path (GET and pack). Writes are throttled and errors are swallowed, but extra DB load and untested SQL in CI remain the main risks.
> 
> **Overview**
> Starts writing `namespace_blobs.last_accessed_at` when blobs are actually served, so a future GC can evict by use instead of upload time.
> 
> Single-blob `GET` and pack `POST` now call a best-effort `touch_blobs`. Failures are logged and never fail the read. Postgres only updates rows older than **1 hour**, so hot blobs cost at most one write per interval. The in-memory store keeps the default no-op. Existence checks (`visible_blobs` / missing-blob) are intentionally not counted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6641ad603e5e9c1f4cb410395583fbfcfbc0788f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->