### PR TITLE
test(metadata): cover the PostgreSQL store in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,24 @@ jobs:
       - run: deploy/ovh/test-deploy.sh
   test:
     runs-on: ubuntu-latest
+    # The PostgreSQL metadata store is the production backend, so the tests run
+    # against a real server rather than only the in-memory store.
+    services:
+      postgres:
+        image: postgres:17-alpine
+        env:
+          POSTGRES_USER: cache
+          POSTGRES_PASSWORD: cache
+          POSTGRES_DB: cache
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U cache"
+          --health-interval 2s
+          --health-timeout 5s
+          --health-retries 15
+    env:
+      MBX_CACHE_TEST_DATABASE_URL: postgres://cache:cache@127.0.0.1:5432/cache
     steps:
       - uses: actions/checkout@v5
         with:

--- a/README.md
+++ b/README.md
@@ -204,7 +204,21 @@ cargo clippy --all-targets --all-features -- -D warnings
 cargo test --all-features
 ```
 
-The protocol specification and mise client live in [jdx/mise](https://github.com/jdx/mise).
+The tests covering the PostgreSQL metadata store need a server to talk to, and
+skip without one. Point them at a throwaway database to run them:
+
+```sh
+docker run --rm -d --name mbx-cache-test-db -p 5432:5432   -e POSTGRES_USER=cache -e POSTGRES_PASSWORD=cache -e POSTGRES_DB=cache   postgres:17-alpine
+MBX_CACHE_TEST_DATABASE_URL=postgres://cache:cache@127.0.0.1:5432/cache   cargo test --all-features
+```
+
+Migrations run automatically, each test uses a namespace of its own, so one
+database serves the whole suite. CI always provides this, and the tests fail
+rather than skip when `CI` is set without a database, so the backend cannot
+quietly go uncovered.
+
+The client that speaks this protocol lives in
+[jdx/mr-boxington](https://github.com/jdx/mr-boxington).
 
 ## License
 

--- a/src/metadata/postgres.rs
+++ b/src/metadata/postgres.rs
@@ -203,9 +203,87 @@ impl MetadataStore for PostgresMetadata {
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeSet;
+    use std::sync::atomic::{AtomicU64, Ordering};
 
-    use super::{MIGRATOR, representable_digests};
-    use crate::model::{Algorithm, Digest};
+    use super::*;
+    use crate::model::Algorithm;
+
+    /// Connect to the database CI provides for the tests below.
+    ///
+    /// A local run without one skips them, but CI must never skip silently:
+    /// these are the only coverage this backend has.
+    async fn store() -> Option<PostgresMetadata> {
+        match std::env::var("MBX_CACHE_TEST_DATABASE_URL") {
+            Ok(url) => Some(
+                PostgresMetadata::connect(&url)
+                    .await
+                    .expect("the test database should accept connections"),
+            ),
+            Err(_) => {
+                assert!(
+                    std::env::var_os("CI").is_none(),
+                    "MBX_CACHE_TEST_DATABASE_URL must be set so CI exercises this backend"
+                );
+                eprintln!(
+                    "skipping: set MBX_CACHE_TEST_DATABASE_URL to run the PostgreSQL metadata tests"
+                );
+                None
+            }
+        }
+    }
+
+    /// A namespace no other test shares, so one database serves them all.
+    fn namespace(label: &str) -> String {
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        format!(
+            "test/{label}/{}/{}",
+            std::process::id(),
+            COUNTER.fetch_add(1, Ordering::Relaxed)
+        )
+    }
+
+    fn test_digest(fill: &str, size: u64) -> Digest {
+        Digest {
+            algorithm: Algorithm::Blake3,
+            hash: fill.repeat(64),
+            size,
+        }
+    }
+
+    fn action_result(action: &Digest, metadata: Option<&Digest>) -> ActionResult {
+        ActionResult {
+            action: action.clone(),
+            metadata: metadata.cloned(),
+            output_root: None,
+            version: 1,
+        }
+    }
+
+    /// The recorded access as text, so a test can assert it did not move.
+    async fn access_timestamp(store: &PostgresMetadata, namespace: &str) -> String {
+        sqlx::query(
+            "SELECT last_accessed_at::text AS stamp FROM namespace_blobs WHERE namespace = $1",
+        )
+        .bind(namespace)
+        .fetch_one(&store.pool)
+        .await
+        .expect("the blob row should exist")
+        .try_get::<String, _>("stamp")
+        .expect("stamp should be text")
+    }
+
+    async fn access_age_seconds(store: &PostgresMetadata, namespace: &str) -> f64 {
+        sqlx::query(
+            "SELECT EXTRACT(EPOCH FROM (now() - last_accessed_at))::float8 AS age \
+             FROM namespace_blobs WHERE namespace = $1",
+        )
+        .bind(namespace)
+        .fetch_one(&store.pool)
+        .await
+        .expect("the blob row should exist")
+        .try_get::<f64, _>("age")
+        .expect("age should be a float")
+    }
 
     #[test]
     fn embedded_migration_versions_are_unique() {
@@ -235,6 +313,170 @@ mod tests {
         assert_eq!(
             representable_digests(&[representable.clone(), unrepresentable]),
             vec![(&representable, i64::MAX)]
+        );
+    }
+    #[tokio::test]
+    async fn blobs_are_visible_only_inside_their_namespace() {
+        let Some(store) = store().await else { return };
+        let mine = namespace("blobs-mine");
+        let theirs = namespace("blobs-theirs");
+        let present = test_digest("a", 10);
+        let absent = test_digest("b", 20);
+
+        store.register_blob(&mine, &present).await.unwrap();
+
+        assert_eq!(
+            store
+                .visible_blobs(&mine, &[present.clone(), absent.clone()])
+                .await
+                .unwrap(),
+            vec![present.clone()],
+            "only the registered blob is visible"
+        );
+        assert!(
+            store
+                .visible_blobs(&theirs, std::slice::from_ref(&present))
+                .await
+                .unwrap()
+                .is_empty(),
+            "another namespace must not see it"
+        );
+        assert!(store.blob_visible(&mine, &present).await.unwrap());
+        assert!(!store.blob_visible(&mine, &absent).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn serving_a_blob_refreshes_a_stale_access_time() {
+        let Some(store) = store().await else { return };
+        let namespace = namespace("touch-stale");
+        let blob = test_digest("c", 30);
+        store.register_blob(&namespace, &blob).await.unwrap();
+        sqlx::query(
+            "UPDATE namespace_blobs SET last_accessed_at = now() - interval '3 days' \
+             WHERE namespace = $1",
+        )
+        .bind(&namespace)
+        .execute(&store.pool)
+        .await
+        .unwrap();
+        assert!(access_age_seconds(&store, &namespace).await > 86_400.0);
+
+        let before = access_timestamp(&store, &namespace).await;
+
+        store.touch_blobs(&namespace, &[blob]).await.unwrap();
+
+        assert_ne!(
+            before,
+            access_timestamp(&store, &namespace).await,
+            "a served blob should record the access"
+        );
+        assert!(
+            access_age_seconds(&store, &namespace).await < 60.0,
+            "and the recorded access should be recent"
+        );
+    }
+
+    #[tokio::test]
+    async fn serving_a_blob_again_leaves_a_fresh_access_time_alone() {
+        let Some(store) = store().await else { return };
+        let namespace = namespace("touch-fresh");
+        let blob = test_digest("d", 40);
+        // Registration already recorded now(), so a read is inside the refresh
+        // interval and must not write.
+        store.register_blob(&namespace, &blob).await.unwrap();
+
+        let before = access_timestamp(&store, &namespace).await;
+        tokio::time::sleep(std::time::Duration::from_millis(1_100)).await;
+        store.touch_blobs(&namespace, &[blob]).await.unwrap();
+        let after = access_timestamp(&store, &namespace).await;
+
+        assert_eq!(
+            before, after,
+            "a blob served inside the refresh interval must cost no write"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_action_result_commits_once_and_reports_conflicts() {
+        let Some(store) = store().await else { return };
+        let elsewhere = namespace("actions-elsewhere");
+        let namespace = namespace("actions");
+        let action = test_digest("e", 50);
+        let result = action_result(&action, None);
+
+        assert_eq!(
+            store.commit(&namespace, &action, &result).await.unwrap(),
+            CommitOutcome::Created
+        );
+        assert_eq!(
+            store.commit(&namespace, &action, &result).await.unwrap(),
+            CommitOutcome::AlreadyExists,
+            "committing identical bytes is not a conflict"
+        );
+        assert_eq!(
+            store
+                .commit(
+                    &namespace,
+                    &action,
+                    &action_result(&action, Some(&test_digest("f", 60)))
+                )
+                .await
+                .unwrap(),
+            CommitOutcome::Conflict,
+            "a different result for the same action is a conflict"
+        );
+
+        let stored = store.get(&namespace, &action).await.unwrap().unwrap();
+        assert_eq!(stored.action, action);
+        assert!(stored.metadata.is_none(), "the first commit wins");
+        assert!(
+            store.get(&elsewhere, &action).await.unwrap().is_none(),
+            "action results do not leak across namespaces"
+        );
+    }
+
+    #[tokio::test]
+    async fn manifest_commits_respect_the_expected_etag() {
+        let Some(store) = store().await else { return };
+        let namespace = namespace("manifests");
+        let key = test_digest("1", 70);
+        let manifest = TaskActionManifest {
+            predictions: Vec::new(),
+            task: "2".repeat(64),
+            version: 1,
+        };
+
+        assert_eq!(
+            store
+                .commit_manifest(&namespace, &key, None, "etag-1", &manifest)
+                .await
+                .unwrap(),
+            ManifestCommitOutcome::Created
+        );
+        assert_eq!(
+            store
+                .commit_manifest(&namespace, &key, Some("etag-1"), "etag-2", &manifest)
+                .await
+                .unwrap(),
+            ManifestCommitOutcome::Updated
+        );
+        assert_eq!(
+            store
+                .commit_manifest(&namespace, &key, Some("etag-1"), "etag-3", &manifest)
+                .await
+                .unwrap(),
+            ManifestCommitOutcome::PreconditionFailed,
+            "a stale etag must not overwrite a newer manifest"
+        );
+
+        assert_eq!(
+            store
+                .get_manifest(&namespace, &key)
+                .await
+                .unwrap()
+                .unwrap()
+                .etag,
+            "etag-2"
         );
     }
 }


### PR DESCRIPTION
The PostgreSQL metadata store is what production runs on, and nothing tested it. The suite only ever exercised `MemoryMetadata`, so every query in `src/metadata/postgres.rs` reached production unexercised — including the one I added in #29.

The test job now runs a `postgres:17-alpine` service and the store is covered against it:

| Test | What it pins down |
| --- | --- |
| `blobs_are_visible_only_inside_their_namespace` | A registered blob is visible in its namespace and invisible in another |
| `an_action_result_commits_once_and_reports_conflicts` | `Created`, then `AlreadyExists` for identical bytes, then `Conflict` for a divergent result; the first commit wins and results do not leak across namespaces |
| `manifest_commits_respect_the_expected_etag` | `Created`, `Updated` with the current etag, `PreconditionFailed` with a stale one — a stale etag must not overwrite a newer manifest |
| `serving_a_blob_refreshes_a_stale_access_time` | A stale record moves when the blob is served |
| `serving_a_blob_again_leaves_a_fresh_access_time_alone` | A blob served inside the refresh interval costs no write |

Namespace isolation for blobs and action results is the one I most wanted covered — it is a security property, and it was resting on a `WHERE` clause nothing checked.

## Not skipping quietly

Tests skip when `MBX_CACHE_TEST_DATABASE_URL` is unset so a plain local `cargo test` still works, but they **fail** when `CI` is set without a database. A skip-if-unset test in CI is indistinguishable from a passing one, which is how this backend went untested in the first place. Verified all three states:

- with the database: the five tests run and pass
- without it, `CI` unset: skipped, with a message saying how to run them
- without it, `CI=1`: `MBX_CACHE_TEST_DATABASE_URL must be set so CI exercises this backend`

## The assertions actually bite

I mutation-tested the two new ones rather than trusting that they passed, and the first attempt did not survive it:

- Neutralising `touch_blobs` failed `serving_a_blob_refreshes_a_stale_access_time`. Good.
- Removing the `AND blobs.last_accessed_at < now() - $5::interval` guard **still passed** the fresh-blob test. It was comparing *ages* either side of a sleep, and both are near zero whether or not a write happened, so it proved nothing.

Both tests now compare the exact `last_accessed_at` value instead, and with that change each mutation fails the test that covers it. Ran the full suite three times against a real database to check the concurrent migrations and shared database do not race — sqlx takes an advisory lock, and each test uses its own namespace.

Also updated the README's Development section with the one-liner for running these locally, and fixed a line there that still pointed at jdx/mise for the client — it lives in jdx/mr-boxington now.

Based on #29 since it tests the code that PR adds; GitHub will retarget this to main when #29 merges.

## One thing left alone

This job uses `dtolnay/rust-toolchain@stable` and mutable action tags (`actions/checkout@v5`, `Swatinem/rust-cache@v2`) while `release-plz.yml` pins by SHA. You mentioned preferring the runner's own Rust, and the inconsistent pinning is worth a look, but changing how the toolchain is provisioned in the same PR that adds a database service would make a red build ambiguous. Happy to do it separately.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and CI-only: no production query or API changes. Main risk is CI flakiness from the new Postgres service and shared-database integration tests.
> 
> **Overview**
> The production PostgreSQL metadata store is now exercised in CI instead of only the in-memory backend.
> 
> The `test` job starts `postgres:17-alpine` and sets `MBX_CACHE_TEST_DATABASE_URL`. New async tests cover namespace isolation for blobs and action results, action-result create/idempotent/conflict, manifest etag create/update/precondition-failed, and `touch_blobs` refreshing stale access times without rewriting fresh ones. Tests skip locally without a URL, but **fail in CI** if the URL is missing so the backend cannot go uncovered.
> 
> README documents a local Docker one-liner and points the protocol client at `jdx/mr-boxington`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 156f85013bc1f0d05fa896ea841ce11e4247bd82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->