### PR TITLE
fix(deploy): print the OIDC subject when the tailnet join fails

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -139,6 +139,39 @@ jobs:
           tags: tag:mise-cache-ci
           ping: mise-cache-prod.tail13c301.ts.net
 
+      # Tailscale refuses the exchange when the trust credential's Subject does
+      # not match the claim GitHub actually sends, and that claim appears in no
+      # log on either side. Print it rather than guessing at it.
+      - name: Explain a failed tailnet join
+        if: failure()
+        env:
+          TS_AUDIENCE: ${{ secrets.TS_AUDIENCE }}
+        run: |
+          response=$(curl --fail --silent --show-error \
+            --get --data-urlencode "audience=$TS_AUDIENCE" \
+            -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "$ACTIONS_ID_TOKEN_REQUEST_URL") || exit 0
+          token=$(jq -er '.value | strings | select(length > 0)' <<<"$response") || exit 0
+          echo "::add-mask::$token"
+          payload=$(cut -d. -f2 <<<"$token" | tr '_-' '/+')
+          case $(( ${#payload} % 4 )) in
+            2) payload="$payload==" ;;
+            3) payload="$payload=" ;;
+          esac
+          claims=$(base64 -d <<<"$payload" 2>/dev/null) || exit 0
+          echo 'The trust credential at https://login.tailscale.com/admin/settings/trust-credentials'
+          echo 'must accept this Subject, exactly:'
+          jq -r '"  \(.sub)"' <<<"$claims"
+          jq -r '"issuer:      \(.iss)\nrepository:  \(.repository)\nenvironment: \(.environment // "<none>")"' <<<"$claims"
+          if [ "$(jq -r '.aud | if type == "array" then join(",") else . end' <<<"$claims")" = "$TS_AUDIENCE" ]; then
+            echo 'audience:    matches TS_AUDIENCE'
+          else
+            echo 'audience:    does NOT match TS_AUDIENCE, so the credential this'
+            echo '             workflow names and the one it targets have diverged'
+          fi
+          echo 'Joining a tailnet also needs write on the auth_keys scope and the'
+          echo 'tag the workflow advertises.'
+
       - name: Configure deployment outputs
         env:
           TF_VAR_cloudflare_account_id: ${{ env.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
Two attempts at fixing the tailnet 403 have been guesswork, because the claim Tailscale rejects appears in no log on either side. This makes the deploy say it.

When the tailnet step fails, a follow-up step requests a token for the same audience and prints:

```
The trust credential at https://login.tailscale.com/admin/settings/trust-credentials
must accept this Subject, exactly:
  repo:jdx/mbx-cache:environment:production
issuer:      https://token.actions.githubusercontent.com
repository:  jdx/mbx-cache
environment: production
audience:    matches TS_AUDIENCE
Joining a tailnet also needs write on the auth_keys scope and the
tag the workflow advertises.
```

That answers the three things we cannot currently see: the exact subject to paste, whether the audience still matches the credential the workflow names, and whether today's repository rename quietly moved this repo to the immutable `repo:jdx@216188/mbx-cache@1320413482:...` form despite the API reporting `use_immutable_subject: false`.

Details worth noting:

- **The token is masked** with `::add-mask::` before anything derived from it is printed, the same pattern the existing `Qualify OIDC, PostgreSQL, and R2` step uses. The subject is not a secret; the token is.
- **The audience is compared, not printed.** `TS_AUDIENCE` is a secret, so printing it would only ever render as `***`. A match/mismatch verdict is the useful part.
- **It cannot mask the real failure.** Every failure path exits zero, so a broken diagnostic never adds a second error on top of the one being diagnosed.
- **It only runs on failure**, so a healthy deploy is unchanged.

## Verification

I extracted the step body and ran it verbatim against a local endpoint serving a synthesised GitHub-shaped token:

| case | result |
| --- | --- |
| audience matches | prints the subject, confirms the match |
| audience diverged | prints the subject, flags that the credential and `TS_AUDIENCE` disagree |
| token endpoint unreachable | prints curl's error, exits 0 |

Also checked the base64url decoder against payloads of every length modulo 4, since a wrong pad would silently produce no output. `shellcheck` is clean and `deploy/ovh/test-deploy.sh` passes.

## Still to settle, separately

While tracing what happens *after* the tailnet joins, I found that the rebrand also renamed 20 host-side identifiers — `/opt/mise-cache`, the compose project, the PostgreSQL role and database, the fail2ban jail, the Grafana dashboard filenames. The live host has all of them under the old names, so a deploy that gets past Tailscale would stand up a second stack beside the running one and contend for ports 80 and 443. I have not touched those here; it needs a decision about whether the host gets renamed or the repository goes back to matching it, and I would rather ask than guess on production.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Failure-only CI diagnostic; the OIDC token is masked and the healthy deploy path is unchanged.
> 
> **Overview**
> When **Join the deployment tailnet** fails, a follow-up step fetches a GitHub OIDC token for `TS_AUDIENCE` and prints the exact `sub` Tailscale must accept, plus issuer, repository, environment, and whether the audience still matches.
> 
> The token is masked before any claims are printed. Diagnostic failures exit 0 so they never hide the original join error. Successful deploys are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9a225f013a1be859458f9da6704fbccd2682199. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added failure-only diagnostics for release connectivity and authentication issues.
  * Error output now includes relevant trust configuration and permission checks while masking sensitive credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->