### PR TITLE
fix(deploy): scope the tailnet diagnostic and bound its request

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -132,6 +132,7 @@ jobs:
       # that live in Tailscale, not in this repository. See "Names that predate
       # the rebrand" in deploy/ovh/README.md before changing either.
       - name: Join the deployment tailnet
+        id: tailnet
         uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8 # v4.1.3
         with:
           oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
@@ -143,11 +144,12 @@ jobs:
       # not match the claim GitHub actually sends, and that claim appears in no
       # log on either side. Print it rather than guessing at it.
       - name: Explain a failed tailnet join
-        if: failure()
+        if: failure() && steps.tailnet.conclusion == 'failure'
         env:
           TS_AUDIENCE: ${{ secrets.TS_AUDIENCE }}
         run: |
           response=$(curl --fail --silent --show-error \
+            --connect-timeout 5 --max-time 15 \
             --get --data-urlencode "audience=$TS_AUDIENCE" \
             -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
             "$ACTIONS_ID_TOKEN_REQUEST_URL") || exit 0


### PR DESCRIPTION
Review follow-up to #32, which merged before I could fold these in. Both findings were valid.

**The diagnostic ran on unrelated failures.** `if: failure()` is true after *any* earlier step fails, so a failing checkout, terraform setup, or mise-action would have printed Tailscale credential guidance as though that were the cause — actively misleading, in a step whose only job is to explain a failure accurately. The tailnet step now carries `id: tailnet` and the diagnostic requires `steps.tailnet.conclusion == 'failure'` as well.

**The token request was unbounded.** No `--connect-timeout` or `--max-time`, so a stalled endpoint would have held the already-failed job open until the 30-minute job timeout. Now 5s to connect, 15s overall.

Verified by extracting the step body and running it verbatim: the output is unchanged when the endpoint answers, and an unroutable address now returns `curl: (28) … Timeout was reached` after 5s and exits 0 rather than hanging.

Credit to both reviewers — CodeRabbit and Cursor independently flagged the `failure()` scoping, and CodeRabbit caught the missing timeouts.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only diagnostic condition and curl timeouts; no change to deploy, auth, or Tailscale join behavior.
> 
> **Overview**
> Tightens the production deploy job’s Tailscale failure diagnostic so it only runs when the tailnet join itself fails, not after unrelated earlier steps.
> 
> Also caps the GitHub OIDC token `curl` at 5s connect / 15s total so a stalled endpoint cannot hold the already-failed job until the 30-minute timeout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1d9f399a91317569b3378855765224f8048e93a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->