### PR TITLE
feat(metadata): sweep the rows expired objects leave behind

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ The OpenMetrics endpoint exposes the existing action and blob counters plus deta
 
 These metrics intentionally use only fixed, low-cardinality labels. Namespaces, repositories, tokens, OIDC claims, and content digests are never exposed as metric labels. Pack duration includes client backpressure through completion of the response body; time to first byte and blob-store response-header latency separate request setup from streaming time.
 
-Do not expire S3 objects independently of PostgreSQL metadata. The metadata store currently assumes a registered blob remains present, so independent object expiration can leave action results pointing at missing blobs. Until coordinated garbage collection is implemented, monitor storage growth and reset the blob and metadata stores together when reclaiming space.
+Expire objects with the bucket's lifecycle rule and sweep the metadata behind it, as described under Bounding storage above. A registered blob is not assumed to be present: a client that cannot fetch one treats the action as a miss and compiles, so an object expiring ahead of its row costs a recompile rather than a failure.
 
 Back up PostgreSQL and enable S3 versioning or replication as required. The service never exposes a deletion endpoint, so retention and disaster recovery remain administrative concerns.
 

--- a/README.md
+++ b/README.md
@@ -178,6 +178,21 @@ Servers advertising `features.blob_packs` accept the same digest-list JSON as `b
 
 ## Operations
 
+### Bounding storage
+
+Blob storage is expired by the bucket's own lifecycle rule; `mbx-cache` removes
+the metadata those objects leave behind and exits without serving:
+
+```sh
+mbx-cache --sweep-metadata-older-than-days 35
+```
+
+It drops blob rows past that age, the action results left referencing them, and
+manifests untouched for that long. Keep the age longer than the storage
+lifecycle so objects go first — reversed, it removes rows for objects that still
+exist and turns cache hits into recompiles. A dangling reference is never fatal:
+a client that cannot fetch a blob treats the action as a miss.
+
 Run multiple stateless replicas against the same PostgreSQL database and S3 bucket. Readiness and liveness probes use `/v1/status`. Scrape `/metrics` with Prometheus.
 
 The OpenMetrics endpoint exposes the existing action and blob counters plus detailed blob-pack telemetry:

--- a/deploy/ovh/README.md
+++ b/deploy/ovh/README.md
@@ -247,12 +247,16 @@ it and treats the action as a miss, so a dangling reference costs a recompile
 rather than a failed build. What it does cost is a wasted round trip on every
 lookup, which is what the sweep removes.
 
-Two things the lifecycle cannot do. It expires by age since upload, not by last
-use, so an object served on every build is still deleted at the cutoff and
-re-uploaded; the server records `last_accessed_at` on reads, but nothing acts on
-it yet. And nested objects inside a directory are not examined when deciding
-whether a result dangles, so a result whose output tree lost one file is swept
-only once its top-level objects go.
+Three things this pairing cannot do. The lifecycle expires by age since upload,
+not by last use, so an object served on every build is still deleted at the
+cutoff and re-uploaded; the server records `last_accessed_at` on reads, but
+nothing acts on it yet. Nested objects inside a directory are not examined when
+deciding whether a result dangles, so a result whose output tree lost one file is
+swept only once its top-level objects go. And a blob row's age is the age of the
+upload that wrote the object, which the first namespace to register an object
+another namespace uploaded earlier cannot know: that row starts its clock late
+and can outlive the object by up to the retention window, until the following
+sweep takes it.
 
 ## Names that predate the rebrand
 

--- a/deploy/ovh/README.md
+++ b/deploy/ovh/README.md
@@ -225,10 +225,34 @@ service definition so startup-loaded configuration changes recreate only
 Prometheus or Grafana as needed. Grafana keeps no mutable state: its exact
 datasource and dashboard set is reprovisioned from these files on recreation.
 
-Do not add an R2 expiration lifecycle yet. The current metadata store does not
-garbage-collect references when objects expire, so independent R2 expiration
-can leave action results pointing at missing blobs. Monitor usage while
-coordinated metadata/blob garbage collection is implemented.
+### Bounding storage
+
+R2 expires the objects through a bucket lifecycle rule, and a metadata sweep
+drops the rows those objects leave behind. Run the two together:
+
+```sh
+# Once, on the bucket: expire objects by age.
+# Then, periodically, on the host:
+docker compose exec cache mbx-cache --sweep-metadata-older-than-days 35
+```
+
+**Keep the sweep's age longer than the lifecycle's.** Storage has to delete
+first so metadata follows it; reversed, the sweep drops rows for objects that
+still exist and every client that wanted one recompiles for nothing.
+
+An earlier note here warned against a lifecycle rule at all, on the grounds that
+expiring objects would leave action results pointing at missing blobs. That part
+is true, but it is not harmful: a client that cannot fetch a referenced blob logs
+it and treats the action as a miss, so a dangling reference costs a recompile
+rather than a failed build. What it does cost is a wasted round trip on every
+lookup, which is what the sweep removes.
+
+Two things the lifecycle cannot do. It expires by age since upload, not by last
+use, so an object served on every build is still deleted at the cutoff and
+re-uploaded; the server records `last_accessed_at` on reads, but nothing acts on
+it yet. And nested objects inside a directory are not examined when deciding
+whether a result dangles, so a result whose output tree lost one file is swept
+only once its top-level objects go.
 
 ## Names that predate the rebrand
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -28,6 +28,15 @@ pub struct Config {
     #[arg(long, env = "MBX_CACHE_DATABASE_URL", default_value = "memory://")]
     pub database_url: String,
 
+    /// Sweep metadata older than this many days, then exit without serving.
+    ///
+    /// R2 expires the objects themselves through a lifecycle rule, which leaves
+    /// their rows behind. Keep this longer than the lifecycle age so storage
+    /// deletes first and metadata follows; the reverse drops rows for objects
+    /// that still exist and costs needless recompiles.
+    #[arg(long, env = "MBX_CACHE_SWEEP_METADATA_OLDER_THAN_DAYS")]
+    pub sweep_metadata_older_than_days: Option<u32>,
+
     #[arg(long, env = "MBX_CACHE_S3_BUCKET")]
     pub s3_bucket: Option<String>,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,8 +24,22 @@ async fn main() -> Result<()> {
         .json()
         .init();
 
-    let blobs = storage::from_config(&config).await?;
     let metadata = metadata::from_url(&config.database_url).await?;
+    // A sweep is an operator action, not part of serving: do it and exit rather
+    // than deleting from under a live server.
+    if let Some(days) = config.sweep_metadata_older_than_days {
+        let swept = metadata.sweep(days).await?;
+        info!(
+            older_than_days = days,
+            blobs = swept.blobs,
+            action_results = swept.action_results,
+            manifests = swept.manifests,
+            "swept metadata"
+        );
+        return Ok(());
+    }
+
+    let blobs = storage::from_config(&config).await?;
     let state = server::AppState::new(
         blobs,
         metadata,

--- a/src/metadata/memory.rs
+++ b/src/metadata/memory.rs
@@ -6,6 +6,7 @@ use std::{
 
 use super::{CommitOutcome, ManifestCommitOutcome, ManifestRecord, MetadataStore};
 use crate::model::{ActionResult, Digest, TaskActionManifest};
+use crate::storage::PutOutcome;
 
 #[derive(Default)]
 pub struct MemoryMetadata {
@@ -29,7 +30,13 @@ impl MetadataStore for MemoryMetadata {
             .collect())
     }
 
-    async fn register_blob(&self, namespace: &str, digest: &Digest) -> anyhow::Result<()> {
+    /// Nothing here ages out, so what the put did to the object does not matter.
+    async fn register_blob(
+        &self,
+        namespace: &str,
+        digest: &Digest,
+        _stored: PutOutcome,
+    ) -> anyhow::Result<()> {
         self.blobs
             .write()
             .expect("metadata lock poisoned")

--- a/src/metadata/mod.rs
+++ b/src/metadata/mod.rs
@@ -19,6 +19,14 @@ pub struct ManifestRecord {
     pub manifest: TaskActionManifest,
 }
 
+/// What a metadata sweep removed.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct SweepOutcome {
+    pub blobs: u64,
+    pub action_results: u64,
+    pub manifests: u64,
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ManifestCommitOutcome {
     Created,
@@ -69,6 +77,12 @@ pub trait MetadataStore: Send + Sync {
         etag: &str,
         manifest: &TaskActionManifest,
     ) -> anyhow::Result<ManifestCommitOutcome>;
+    /// Drop metadata for objects storage has already expired.
+    ///
+    /// Stores without durable metadata have nothing to sweep.
+    async fn sweep(&self, _older_than_days: u32) -> anyhow::Result<SweepOutcome> {
+        Ok(SweepOutcome::default())
+    }
 }
 
 pub async fn from_url(url: &str) -> anyhow::Result<std::sync::Arc<dyn MetadataStore>> {

--- a/src/metadata/mod.rs
+++ b/src/metadata/mod.rs
@@ -2,6 +2,7 @@ mod memory;
 mod postgres;
 
 use crate::model::{ActionResult, Digest, TaskActionManifest};
+use crate::storage::PutOutcome;
 use async_trait::async_trait;
 
 pub use memory::MemoryMetadata;
@@ -47,7 +48,20 @@ pub trait MetadataStore: Send + Sync {
             .await?
             .is_empty())
     }
-    async fn register_blob(&self, namespace: &str, digest: &Digest) -> anyhow::Result<()>;
+    /// Record that a namespace holds this blob.
+    ///
+    /// `stored` is what the upload did to the object, and it decides whether
+    /// the recorded age restarts. A `Created` object's age in storage starts
+    /// now; an `AlreadyExists` one keeps the age it already had, because the
+    /// put was refused and the object was not rewritten. Moving metadata
+    /// forward for an object that did not move is what leaves a row outliving
+    /// the object a lifecycle rule expires.
+    async fn register_blob(
+        &self,
+        namespace: &str,
+        digest: &Digest,
+        stored: PutOutcome,
+    ) -> anyhow::Result<()>;
     /// Record that these blobs were served to a client.
     ///
     /// `namespace_blobs.last_accessed_at` otherwise only ever holds the time a

--- a/src/metadata/postgres.rs
+++ b/src/metadata/postgres.rs
@@ -3,6 +3,7 @@ use sqlx::{PgPool, Row};
 
 use super::{CommitOutcome, ManifestCommitOutcome, ManifestRecord, MetadataStore, SweepOutcome};
 use crate::model::{ActionResult, Digest, TaskActionManifest};
+use crate::storage::PutOutcome;
 
 static MIGRATOR: sqlx::migrate::Migrator = sqlx::migrate!();
 
@@ -168,22 +169,36 @@ impl MetadataStore for PostgresMetadata {
         Ok(())
     }
 
-    async fn register_blob(&self, namespace: &str, digest: &Digest) -> anyhow::Result<()> {
-        // Registering again means a client uploaded this digest again, which
-        // resets the object's age in storage. Carrying the original timestamp
-        // forward would let the sweep delete metadata for an object that is
-        // present, costing a recompile and orphaning the object until its own
-        // expiry.
+    async fn register_blob(
+        &self,
+        namespace: &str,
+        digest: &Digest,
+        stored: PutOutcome,
+    ) -> anyhow::Result<()> {
+        // `created_at` has to track the object's age in storage, since that is
+        // what a lifecycle rule expires and what `sweep` follows. An upload
+        // that wrote the object restarts both, so the row follows it; one
+        // refused because the object was already there restarts neither, and
+        // moving the row forward would leave it visible long after the
+        // lifecycle deleted the object it names.
+        //
+        // A first registration of an object another namespace uploaded earlier
+        // is the one case this cannot get right: the row starts at now() while
+        // the object is already partway to its expiry, so it can outlive the
+        // object by up to the retention window. The next sweep after that
+        // removes it.
         sqlx::query(
             "INSERT INTO namespace_blobs (namespace, algorithm, hash, size) \
              VALUES ($1, $2, $3, $4) \
              ON CONFLICT (namespace, algorithm, hash, size) DO UPDATE \
-             SET created_at = now(), last_accessed_at = now()",
+             SET created_at = CASE WHEN $5 THEN now() ELSE namespace_blobs.created_at END, \
+                 last_accessed_at = now()",
         )
         .bind(namespace)
         .bind(digest.algorithm.to_string())
         .bind(&digest.hash)
         .bind(digest.size as i64)
+        .bind(matches!(stored, PutOutcome::Created))
         .execute(&self.pool)
         .await?;
         Ok(())
@@ -409,7 +424,10 @@ mod tests {
         let _serialized = SWEEP.lock().await;
         let namespace = namespace("sweep-recent");
         let action = test_digest("2", 10);
-        store.register_blob(&namespace, &action).await.unwrap();
+        store
+            .register_blob(&namespace, &action, PutOutcome::Created)
+            .await
+            .unwrap();
         store
             .commit(&namespace, &action, &action_result(&action, None))
             .await
@@ -430,8 +448,14 @@ mod tests {
         let namespace = namespace("sweep-expired");
         let action = test_digest("3", 20);
         let metadata = test_digest("4", 30);
-        store.register_blob(&namespace, &action).await.unwrap();
-        store.register_blob(&namespace, &metadata).await.unwrap();
+        store
+            .register_blob(&namespace, &action, PutOutcome::Created)
+            .await
+            .unwrap();
+        store
+            .register_blob(&namespace, &metadata, PutOutcome::Created)
+            .await
+            .unwrap();
         store
             .commit(
                 &namespace,
@@ -459,12 +483,18 @@ mod tests {
         let _serialized = SWEEP.lock().await;
         let namespace = namespace("sweep-reuploaded");
         let blob = test_digest("9", 70);
-        store.register_blob(&namespace, &blob).await.unwrap();
+        store
+            .register_blob(&namespace, &blob, PutOutcome::Created)
+            .await
+            .unwrap();
         backdate(&store, &namespace, 40).await;
 
-        // Storage expired the object and a client uploaded it again, so its age
+        // Storage expired the object and the upload wrote it again, so its age
         // there restarted and the row has to follow.
-        store.register_blob(&namespace, &blob).await.unwrap();
+        store
+            .register_blob(&namespace, &blob, PutOutcome::Created)
+            .await
+            .unwrap();
 
         assert_eq!(
             store.sweep(30).await.unwrap().blobs,
@@ -475,14 +505,48 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn a_sweep_expires_a_blob_the_upload_did_not_rewrite() {
+        let Some(store) = store().await else { return };
+        let _serialized = SWEEP.lock().await;
+        let namespace = namespace("sweep-upload-refused");
+        let blob = test_digest("9", 80);
+        store
+            .register_blob(&namespace, &blob, PutOutcome::Created)
+            .await
+            .unwrap();
+        backdate(&store, &namespace, 40).await;
+
+        // The put was refused because the object was already there, so its age
+        // in storage did not move and neither may the row's. Refreshing here
+        // would keep the row past the lifecycle rule that deletes the object.
+        store
+            .register_blob(&namespace, &blob, PutOutcome::AlreadyExists)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            store.sweep(30).await.unwrap().blobs,
+            1,
+            "an upload that rewrote nothing does not extend the row"
+        );
+        assert!(!store.blob_visible(&namespace, &blob).await.unwrap());
+    }
+
+    #[tokio::test]
     async fn a_sweep_keeps_a_result_whose_objects_are_still_there() {
         let Some(store) = store().await else { return };
         let _serialized = SWEEP.lock().await;
         let namespace = namespace("sweep-live-result");
         let action = test_digest("5", 40);
         let metadata = test_digest("6", 50);
-        store.register_blob(&namespace, &action).await.unwrap();
-        store.register_blob(&namespace, &metadata).await.unwrap();
+        store
+            .register_blob(&namespace, &action, PutOutcome::Created)
+            .await
+            .unwrap();
+        store
+            .register_blob(&namespace, &metadata, PutOutcome::Created)
+            .await
+            .unwrap();
         store
             .commit(
                 &namespace,
@@ -545,7 +609,10 @@ mod tests {
         let present = test_digest("a", 10);
         let absent = test_digest("b", 20);
 
-        store.register_blob(&mine, &present).await.unwrap();
+        store
+            .register_blob(&mine, &present, PutOutcome::Created)
+            .await
+            .unwrap();
 
         assert_eq!(
             store
@@ -572,7 +639,10 @@ mod tests {
         let Some(store) = store().await else { return };
         let namespace = namespace("touch-stale");
         let blob = test_digest("c", 30);
-        store.register_blob(&namespace, &blob).await.unwrap();
+        store
+            .register_blob(&namespace, &blob, PutOutcome::Created)
+            .await
+            .unwrap();
         sqlx::query(
             "UPDATE namespace_blobs SET last_accessed_at = now() - interval '3 days' \
              WHERE namespace = $1",
@@ -605,7 +675,10 @@ mod tests {
         let blob = test_digest("d", 40);
         // Registration already recorded now(), so a read is inside the refresh
         // interval and must not write.
-        store.register_blob(&namespace, &blob).await.unwrap();
+        store
+            .register_blob(&namespace, &blob, PutOutcome::Created)
+            .await
+            .unwrap();
 
         let before = access_timestamp(&store, &namespace).await;
         tokio::time::sleep(std::time::Duration::from_millis(1_100)).await;

--- a/src/metadata/postgres.rs
+++ b/src/metadata/postgres.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use sqlx::{PgPool, Row};
 
-use super::{CommitOutcome, ManifestCommitOutcome, ManifestRecord, MetadataStore};
+use super::{CommitOutcome, ManifestCommitOutcome, ManifestRecord, MetadataStore, SweepOutcome};
 use crate::model::{ActionResult, Digest, TaskActionManifest};
 
 static MIGRATOR: sqlx::migrate::Migrator = sqlx::migrate!();
@@ -75,6 +75,60 @@ impl MetadataStore for PostgresMetadata {
                     .ok_or_else(|| anyhow::anyhow!("database returned an invalid blob ordinal"))
             })
             .collect()
+    }
+
+    async fn sweep(&self, older_than_days: u32) -> anyhow::Result<SweepOutcome> {
+        let age = format!("{older_than_days} days");
+        // One transaction, so no reader sees a result whose blobs this sweep
+        // has already removed. Blobs go first; the dangling query below then
+        // observes the post-delete state.
+        let mut transaction = self.pool.begin().await?;
+        let blobs =
+            sqlx::query("DELETE FROM namespace_blobs WHERE created_at < now() - $1::interval")
+                .bind(&age)
+                .execute(&mut *transaction)
+                .await?
+                .rows_affected();
+
+        // A result whose objects are gone can only produce a miss, and it costs
+        // a wasted round trip every time a client asks for it. Only the
+        // top-level objects are checked: a directory that lost a nested object
+        // still restores as a miss, which is safe.
+        let action_results = sqlx::query(
+            "DELETE FROM action_results AS results \
+             WHERE EXISTS ( \
+               SELECT 1 \
+               FROM (VALUES (results.result -> 'metadata'), \
+                            (results.result -> 'output_root')) AS referenced(digest) \
+               WHERE jsonb_typeof(referenced.digest) = 'object' \
+                 AND NOT EXISTS ( \
+                   SELECT 1 FROM namespace_blobs AS blobs \
+                   WHERE blobs.namespace = results.namespace \
+                     AND blobs.algorithm = referenced.digest ->> 'algorithm' \
+                     AND blobs.hash = referenced.digest ->> 'hash' \
+                     AND blobs.size = (referenced.digest ->> 'size')::bigint \
+                 ) \
+             )",
+        )
+        .execute(&mut *transaction)
+        .await?
+        .rows_affected();
+
+        // Manifests only predict actions, so an old one costs a cold prefetch
+        // rather than a wrong answer. They are aged out on their own use.
+        let manifests =
+            sqlx::query("DELETE FROM action_manifests WHERE updated_at < now() - $1::interval")
+                .bind(&age)
+                .execute(&mut *transaction)
+                .await?
+                .rows_affected();
+
+        transaction.commit().await?;
+        Ok(SweepOutcome {
+            blobs,
+            action_results,
+            manifests,
+        })
     }
 
     async fn touch_blobs(&self, namespace: &str, digests: &[Digest]) -> anyhow::Result<()> {
@@ -315,6 +369,131 @@ mod tests {
             vec![(&representable, i64::MAX)]
         );
     }
+    /// Age a namespace's rows so the sweep sees them as expired.
+    async fn backdate(store: &PostgresMetadata, namespace: &str, days: u32) {
+        for statement in [
+            "UPDATE namespace_blobs SET created_at = now() - ($2 || ' days')::interval WHERE namespace = $1",
+            "UPDATE action_results SET created_at = now() - ($2 || ' days')::interval WHERE namespace = $1",
+            "UPDATE action_manifests SET updated_at = now() - ($2 || ' days')::interval WHERE namespace = $1",
+        ] {
+            sqlx::query(statement)
+                .bind(namespace)
+                .bind(days.to_string())
+                .execute(&store.pool)
+                .await
+                .expect("backdating should succeed");
+        }
+    }
+
+    #[tokio::test]
+    async fn a_sweep_leaves_recent_metadata_alone() {
+        let Some(store) = store().await else { return };
+        let namespace = namespace("sweep-recent");
+        let action = test_digest("2", 10);
+        store.register_blob(&namespace, &action).await.unwrap();
+        store
+            .commit(&namespace, &action, &action_result(&action, None))
+            .await
+            .unwrap();
+
+        let swept = store.sweep(30).await.unwrap();
+
+        assert_eq!(swept.blobs, 0, "a fresh blob is not expired");
+        assert!(store.blob_visible(&namespace, &action).await.unwrap());
+        assert!(store.get(&namespace, &action).await.unwrap().is_some());
+        let _ = swept.manifests;
+    }
+
+    #[tokio::test]
+    async fn a_sweep_drops_expired_blobs_and_the_results_left_dangling() {
+        let Some(store) = store().await else { return };
+        let namespace = namespace("sweep-expired");
+        let action = test_digest("3", 20);
+        let metadata = test_digest("4", 30);
+        store.register_blob(&namespace, &action).await.unwrap();
+        store.register_blob(&namespace, &metadata).await.unwrap();
+        store
+            .commit(
+                &namespace,
+                &action,
+                &action_result(&action, Some(&metadata)),
+            )
+            .await
+            .unwrap();
+        backdate(&store, &namespace, 40).await;
+
+        let swept = store.sweep(30).await.unwrap();
+
+        assert_eq!(swept.blobs, 2, "both expired blobs go");
+        assert_eq!(
+            swept.action_results, 1,
+            "the result referencing them cannot survive them"
+        );
+        assert!(!store.blob_visible(&namespace, &action).await.unwrap());
+        assert!(store.get(&namespace, &action).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn a_sweep_keeps_a_result_whose_objects_are_still_there() {
+        let Some(store) = store().await else { return };
+        let namespace = namespace("sweep-live-result");
+        let action = test_digest("5", 40);
+        let metadata = test_digest("6", 50);
+        store.register_blob(&namespace, &action).await.unwrap();
+        store.register_blob(&namespace, &metadata).await.unwrap();
+        store
+            .commit(
+                &namespace,
+                &action,
+                &action_result(&action, Some(&metadata)),
+            )
+            .await
+            .unwrap();
+        // Age only the result. Its objects are current, so it is still useful.
+        sqlx::query(
+            "UPDATE action_results SET created_at = now() - interval '40 days' WHERE namespace = $1",
+        )
+        .bind(&namespace)
+        .execute(&store.pool)
+        .await
+        .unwrap();
+
+        let swept = store.sweep(30).await.unwrap();
+
+        assert_eq!(
+            swept.action_results, 0,
+            "age alone does not expire a result"
+        );
+        assert!(store.get(&namespace, &action).await.unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn a_sweep_expires_manifests_by_their_last_update() {
+        let Some(store) = store().await else { return };
+        let namespace = namespace("sweep-manifests");
+        let key = test_digest("7", 60);
+        let manifest = TaskActionManifest {
+            predictions: Vec::new(),
+            task: "8".repeat(64),
+            version: 1,
+        };
+        store
+            .commit_manifest(&namespace, &key, None, "etag-1", &manifest)
+            .await
+            .unwrap();
+
+        assert_eq!(store.sweep(30).await.unwrap().manifests, 0);
+        backdate(&store, &namespace, 40).await;
+        assert_eq!(store.sweep(30).await.unwrap().manifests, 1);
+        assert!(
+            store
+                .get_manifest(&namespace, &key)
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+
     #[tokio::test]
     async fn blobs_are_visible_only_inside_their_namespace() {
         let Some(store) = store().await else { return };

--- a/src/metadata/postgres.rs
+++ b/src/metadata/postgres.rs
@@ -169,9 +169,23 @@ impl MetadataStore for PostgresMetadata {
     }
 
     async fn register_blob(&self, namespace: &str, digest: &Digest) -> anyhow::Result<()> {
-        sqlx::query("INSERT INTO namespace_blobs (namespace, algorithm, hash, size) VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING")
-            .bind(namespace).bind(digest.algorithm.to_string()).bind(&digest.hash).bind(digest.size as i64)
-            .execute(&self.pool).await?;
+        // Registering again means a client uploaded this digest again, which
+        // resets the object's age in storage. Carrying the original timestamp
+        // forward would let the sweep delete metadata for an object that is
+        // present, costing a recompile and orphaning the object until its own
+        // expiry.
+        sqlx::query(
+            "INSERT INTO namespace_blobs (namespace, algorithm, hash, size) \
+             VALUES ($1, $2, $3, $4) \
+             ON CONFLICT (namespace, algorithm, hash, size) DO UPDATE \
+             SET created_at = now(), last_accessed_at = now()",
+        )
+        .bind(namespace)
+        .bind(digest.algorithm.to_string())
+        .bind(&digest.hash)
+        .bind(digest.size as i64)
+        .execute(&self.pool)
+        .await?;
         Ok(())
     }
 
@@ -369,6 +383,10 @@ mod tests {
             vec![(&representable, i64::MAX)]
         );
     }
+    /// A sweep deletes across every namespace, so tests that age rows and count
+    /// what went have to take turns.
+    static SWEEP: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
     /// Age a namespace's rows so the sweep sees them as expired.
     async fn backdate(store: &PostgresMetadata, namespace: &str, days: u32) {
         for statement in [
@@ -388,6 +406,7 @@ mod tests {
     #[tokio::test]
     async fn a_sweep_leaves_recent_metadata_alone() {
         let Some(store) = store().await else { return };
+        let _serialized = SWEEP.lock().await;
         let namespace = namespace("sweep-recent");
         let action = test_digest("2", 10);
         store.register_blob(&namespace, &action).await.unwrap();
@@ -407,6 +426,7 @@ mod tests {
     #[tokio::test]
     async fn a_sweep_drops_expired_blobs_and_the_results_left_dangling() {
         let Some(store) = store().await else { return };
+        let _serialized = SWEEP.lock().await;
         let namespace = namespace("sweep-expired");
         let action = test_digest("3", 20);
         let metadata = test_digest("4", 30);
@@ -434,8 +454,30 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn a_sweep_keeps_a_blob_that_was_uploaded_again() {
+        let Some(store) = store().await else { return };
+        let _serialized = SWEEP.lock().await;
+        let namespace = namespace("sweep-reuploaded");
+        let blob = test_digest("9", 70);
+        store.register_blob(&namespace, &blob).await.unwrap();
+        backdate(&store, &namespace, 40).await;
+
+        // Storage expired the object and a client uploaded it again, so its age
+        // there restarted and the row has to follow.
+        store.register_blob(&namespace, &blob).await.unwrap();
+
+        assert_eq!(
+            store.sweep(30).await.unwrap().blobs,
+            0,
+            "a re-uploaded object is not expired"
+        );
+        assert!(store.blob_visible(&namespace, &blob).await.unwrap());
+    }
+
+    #[tokio::test]
     async fn a_sweep_keeps_a_result_whose_objects_are_still_there() {
         let Some(store) = store().await else { return };
+        let _serialized = SWEEP.lock().await;
         let namespace = namespace("sweep-live-result");
         let action = test_digest("5", 40);
         let metadata = test_digest("6", 50);
@@ -470,6 +512,7 @@ mod tests {
     #[tokio::test]
     async fn a_sweep_expires_manifests_by_their_last_update() {
         let Some(store) = store().await else { return };
+        let _serialized = SWEEP.lock().await;
         let namespace = namespace("sweep-manifests");
         let key = test_digest("7", 60);
         let manifest = TaskActionManifest {

--- a/src/server.rs
+++ b/src/server.rs
@@ -203,7 +203,7 @@ async fn put_blob(
         .map_err(ApiError::internal)?;
     state
         .metadata
-        .register_blob(&namespace, &digest)
+        .register_blob(&namespace, &digest, outcome)
         .await
         .map_err(ApiError::internal)?;
     state.metrics.inc_blob_upload();


### PR DESCRIPTION
Storage was unbounded on both sides: nothing removed objects, and the obvious fix — an R2 lifecycle rule — was ruled out by a note in `deploy/ovh/README.md` saying expiring objects would leave action results pointing at missing blobs.

That turns out to be true but not harmful, and checking it changed the design. `find_blob` catches a failed fetch, logs it, and returns no path, so the shim treats the action as a miss and compiles:

```rust
Err(error) => {
    warn!("remote cache blob lookup failed for {}: {error}", digest.hash);
    Ok(AgentResponse::Blob { path: None })
}
```

A dangling reference costs a recompile, not a failed build. What it *does* cost is a wasted round trip on every lookup, forever, because the row never goes away — the client asks, the server says the blob is visible, storage 404s.

So the lifecycle rule can own the bytes and this owns the rows. `--sweep-metadata-older-than-days` runs one transaction and exits without serving:

```
{"message":"swept metadata","older_than_days":30,"blobs":1,"action_results":1,"manifests":0}
```

- **blob rows** past the age — the objects R2 has already expired
- **action results left dangling** by them, by reference rather than by age
- **manifests** untouched for that long, since a stale one only costs a cold prefetch

Two ordering details carry the correctness. Blobs are deleted first so the dangling query observes the post-delete state, and it is all one transaction so no reader sees a result whose objects this sweep just removed.

Deleting results by *danglingness* rather than by age is the part worth arguing for: a result whose objects are current is still useful however old it is, and aging it out would throw away hits for nothing.

## Shape

A flag rather than a subcommand, because `Config` is a flat clap struct and the running server is invoked through it — adding a subcommand would have changed how the deployment starts the server for no benefit. A sweep is an operator action, so it deletes and exits rather than running inside a live server; that also keeps it schedulable by cron without a background task in the serving path.

## Verification

Postgres tests, on the harness #30 added:

| test | pins down |
| --- | --- |
| `a_sweep_leaves_recent_metadata_alone` | fresh rows survive |
| `a_sweep_drops_expired_blobs_and_the_results_left_dangling` | both expired blobs and the result referencing them go |
| `a_sweep_keeps_a_result_whose_objects_are_still_there` | age alone does not expire a result |
| `a_sweep_expires_manifests_by_their_last_update` | manifests age out on `updated_at` |
| `a_sweep_keeps_a_blob_that_was_uploaded_again` | an upload that rewrote the object restarts the row's age |
| `a_sweep_expires_a_blob_the_upload_did_not_rewrite` | one refused because the object was there does not |

Mutation-tested rather than assumed, after being burned by a test that looked fine and did not bite:

- stubbing out the dangling delete → `a_sweep_drops_expired…` fails
- swapping danglingness for an age predicate → `a_sweep_keeps_a_result…` fails

Also ran it through the real binary against PostgreSQL 17: seeded a 90-day-old blob and a result referencing it, swept at 30 days, and both rows went while the process exited without listening. Confirmed the normal server path still starts and serves with the flag absent. 38 tests, clippy clean with `-D warnings`, shellcheck clean, `test-deploy.sh` passes.

## Documentation

`deploy/ovh/README.md` gains a **Bounding storage** section pairing the lifecycle rule with the sweep, and the old warning is corrected rather than deleted — it was right that references dangle and wrong that it matters, and the distinction is why this approach works.

It also records three things this pairing genuinely cannot do. The lifecycle expires by age since upload rather than last use, so an object served on every build is still deleted at the cutoff and re-uploaded; `last_accessed_at` is recorded now but nothing acts on it. Nested objects inside a directory are not examined when deciding whether a result dangles. And a namespace's first registration of an object another namespace uploaded earlier starts the row's clock late, since nothing records when that object was written, so it can outlive the object by up to the retention window.

## Follow-up worth considering

The server could refresh an object's age in storage on access — an S3 copy-in-place resets `Last-Modified` — which would turn the age-based lifecycle into approximate LRU driven by the tracking #29 added, with the same interval guard keeping it to one operation per object per hour. Worth doing once there are real hit patterns to look at, not before.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Deletes production PostgreSQL metadata across all namespaces in one transaction. A mis-set age relative to the bucket lifecycle can drop live cache hits and force recompiles.
> 
> **Overview**
> Lets operators reclaim unbounded Postgres metadata after R2/S3 lifecycle expiry. `--sweep-metadata-older-than-days` (or `MBX_CACHE_SWEEP_METADATA_OLDER_THAN_DAYS`) runs a one-shot sweep and exits without serving.
> 
> The Postgres sweep is a single transaction: aged `namespace_blobs` first, then action results whose top-level `metadata`/`output_root` no longer resolve, then manifests past `updated_at`. Results are dropped for danglingness, not age, so a still-backed result stays.
> 
> `register_blob` now takes `PutOutcome` so `created_at` only restarts when the object was actually rewritten (`Created`). A refused put (`AlreadyExists`) keeps the old age so the row cannot outlive the lifecycle object.
> 
> Docs replace the “do not expire objects” warning with a paired lifecycle + sweep procedure and the known limits (age-not-LRU, nested trees, cross-namespace first registration).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66123ef642ed79c6b57d3df8efb224c16e447a04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional metadata cleanup mode for removing stale records after object-storage expiration.
  * Cleanup reports removed blobs, action results, and manifests, then exits without starting the server.
  * Added command-line and environment-variable configuration.
  * Missing objects are handled as cache misses, allowing recompilation instead of failing requests.

* **Documentation**
  * Updated operations guidance for coordinating storage lifecycle rules with metadata cleanup.
  * Documented lifecycle timing limitations and preserved manifest metadata during cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

