### PR TITLE
feat(deploy): trust every jdx.dev Rust project

### DIFF
--- a/deploy/ovh/test-deploy.sh
+++ b/deploy/ovh/test-deploy.sh
@@ -64,12 +64,14 @@ grep -Fq "MBX_CACHE_GRAFANA_CONFIG_HASH=\"$grafana_config_hash\"" "$project_dir/
 grep -Fq 'AWS_ACCESS_KEY_ID="r2-access-key"' "$project_dir/runtime/cache.env"
 grep -Fq 'AWS_SECRET_ACCESS_KEY="r2-secret-key"' "$project_dir/runtime/cache.env"
 oidc_json=$(sed -n 's/^MBX_CACHE_OIDC_PROVIDERS_JSON=//p' "$project_dir/runtime/cache.env" | jq -c fromjson)
-jq -e '
+jq -e --argjson repositories "${MBX_CACHE_TEST_REPOSITORIES:?}" '
   .[0].rules as $rules |
-  ["jdx/mise", "jdx/aube", "jdx/usage"] as $repositories |
   # Four rules per trusted repository -- protected-main push, tag, pull
-  # request, other push -- plus the single deployment rule. Derived rather
-  # than written out, so adding a repository does not fail this on a number.
+  # request, other push -- plus the single deployment rule. Both the list and
+  # the count come from the allowlist the deploy just consumed, so adding a
+  # repository does not fail this on a restated name or a stale number. What
+  # is still checked is that every configured repository got exactly those
+  # four rules and that nothing generated a rule beyond them.
   ($rules | length == ($repositories | length) * 4 + 1) and
   ($repositories | all(. as $repository |
     ($rules | any(
@@ -119,8 +121,13 @@ fi
 SH
 chmod 0755 "$test_root/bin/fake-terraform" "$test_root/bin/mise"
 
+# The rule assertions in the fake mise above run in a quoted heredoc, so the
+# allowlist has to reach them through the environment rather than expansion.
+trusted_repositories=$(jq -c 'map(.repository)' "$script_dir/trusted-repositories.json")
+
 common_env=(
   "CAPTURE_DIR=$test_root/capture"
+  "MBX_CACHE_TEST_REPOSITORIES=$trusted_repositories"
   "MBX_CACHE_DATABASE_PASSWORD=database_password_123456"
   "MBX_CACHE_IMAGE=ghcr.io/jdx/mbx-cache@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
   "OVH_SSH_HOST=mbx-cache-prod.tailnet.example"

--- a/deploy/ovh/test-deploy.sh
+++ b/deploy/ovh/test-deploy.sh
@@ -66,8 +66,12 @@ grep -Fq 'AWS_SECRET_ACCESS_KEY="r2-secret-key"' "$project_dir/runtime/cache.env
 oidc_json=$(sed -n 's/^MBX_CACHE_OIDC_PROVIDERS_JSON=//p' "$project_dir/runtime/cache.env" | jq -c fromjson)
 jq -e '
   .[0].rules as $rules |
-  ($rules | length == 9) and
-  (["jdx/mise", "jdx/aube"] | all(. as $repository |
+  ["jdx/mise", "jdx/aube", "jdx/usage"] as $repositories |
+  # Four rules per trusted repository -- protected-main push, tag, pull
+  # request, other push -- plus the single deployment rule. Derived rather
+  # than written out, so adding a repository does not fail this on a number.
+  ($rules | length == ($repositories | length) * 4 + 1) and
+  ($repositories | all(. as $repository |
     ($rules | any(
       .claims.repository == $repository and
       .claims.repository_owner_id == "216188" and

--- a/deploy/ovh/trusted-repositories.json
+++ b/deploy/ovh/trusted-repositories.json
@@ -10,5 +10,29 @@
   {
     "repository": "jdx/usage",
     "repository_owner_id": "216188"
+  },
+  {
+    "repository": "jdx/fnox",
+    "repository_owner_id": "216188"
+  },
+  {
+    "repository": "jdx/hk",
+    "repository_owner_id": "216188"
+  },
+  {
+    "repository": "jdx/pitchfork",
+    "repository_owner_id": "216188"
+  },
+  {
+    "repository": "jdx/communique",
+    "repository_owner_id": "216188"
+  },
+  {
+    "repository": "jdx/demand",
+    "repository_owner_id": "216188"
+  },
+  {
+    "repository": "jdx/tak",
+    "repository_owner_id": "216188"
   }
 ]

--- a/deploy/ovh/trusted-repositories.json
+++ b/deploy/ovh/trusted-repositories.json
@@ -6,5 +6,9 @@
   {
     "repository": "jdx/aube",
     "repository_owner_id": "216188"
+  },
+  {
+    "repository": "jdx/usage",
+    "repository_owner_id": "216188"
   }
 ]


### PR DESCRIPTION
[jdx/usage#1194](https://github.com/jdx/usage/pull/1194) added an mbx dogfood job, and every request it makes to this server is refused — not only writes but reads, since a repository absent from `trusted-repositories.json` has no grant at all:

```
403 Forbidden  https://cache.mise.jdx.dev/v1/blobs/blake3/…
403 Forbidden  https://cache.mise.jdx.dev/v1/action-manifests/blake3/…
```

This grants all nine projects listed on jdx.dev. `mise` and `aube` already had grants; `usage`, `fnox`, `hk`, `pitchfork`, `communique`, `demand` and `tak` join them. Every one is Rust, which is the only kind of build mbx can cache.

One judgement call: **`demand` is a library, not a CLI.** It is included because it builds Rust in CI like the rest, not because it belongs on a list of CLIs. Say the word and I will drop it.

## What it widens

Each listed repository gets read/write from pushes to its protected `main`, and read-only for tags, pull requests and other pushes — the same shape `mise` and `aube` already have, with namespace isolation keeping each repository's objects apart. No new grant *shape*, nine times the surface.

Worth noting the client behaved correctly while unauthorized: mbx judged the protected-branch push a trusted writer, attempted its uploads, and degraded every 403 to a warning rather than failing someone else's build. The dogfood job went green while being refused by this server, which is the intended failure mode.

## The test change

`test-deploy.sh` asserted `$rules | length == 9` and named `["jdx/mise", "jdx/aube"]` explicitly. Both went stale the moment a repository was added — the first commit here failed CI on exactly that, which is how the problem announced itself. With nine repositories it would be a standing invitation to the same failure.

The list and the count now both derive from the allowlist the deploy just consumed. That gives up a double entry: the test no longer notices a repository *disappearing* from the allowlist. That is a config change, visible in the diff of the file itself, rather than a deploy bug — a worse thing to catch here than what the staleness cost.

What it still checks is that every configured repository generates exactly its four rules and that nothing generates a rule beyond them. Verified by breaking the arithmetic on purpose: with `* 5 + 1` the suite fails, with `* 4 + 1` it passes, so the count is live rather than decorative.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*