### PR TITLE
feat(server): compress transfers with zstd when the client asks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,6 +104,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
+name = "async-compression"
+version = "0.4.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3976abdc8fe7d1133d43d304afd42abdf5bc3e1319d263d223bde07b5efc4be8"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -835,6 +847,23 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
+dependencies = [
+ "compression-core",
+ "zstd",
+ "zstd-safe",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "const-oid"
@@ -1823,6 +1852,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
+ "zstd",
 ]
 
 [[package]]
@@ -3144,13 +3174,17 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
+ "async-compression",
  "bitflags",
  "bytes",
+ "futures-core",
  "futures-util",
  "http 1.5.0",
  "http-body 1.1.0",
  "http-body-util",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
@@ -3805,3 +3839,31 @@ name = "zmij"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,11 +42,17 @@ tempfile = "3"
 thiserror = "2"
 tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["io"] }
-tower-http = { version = "0.6", features = ["limit", "trace"] }
+tower-http = { version = "0.6", features = [
+  "compression-zstd",
+  "decompression-zstd",
+  "limit",
+  "trace",
+] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 
 [dev-dependencies]
+zstd = "0.13"
 http-body-util = "0.1"
 rsa = { version = "0.9", features = ["pem"] }
 tower = { version = "0.5", features = ["util"] }

--- a/src/server.rs
+++ b/src/server.rs
@@ -66,13 +66,29 @@ impl AppState {
 
 pub fn router(state: AppState) -> Router {
     let limit = usize::try_from(state.max_blob_bytes).unwrap_or(usize::MAX);
-    Router::new()
-        .route("/v1/status", get(status))
-        .route("/v1/capabilities", get(capabilities))
+    // Blob uploads are the only compressed requests, so decompression is
+    // scoped to them rather than applied to every route. The JSON handlers
+    // buffer and parse their whole body before they authenticate anyone, and
+    // there is no reason to let an unauthenticated caller spend a few
+    // kilobytes to fill that buffer. Axum's own 2 MB default bounds them --
+    // `json_routes_keep_axums_default_body_limit` pins it -- and the largest
+    // legitimate request, MAX_BATCH_ITEMS digests, is about 1.1 MB.
+    let blobs = Router::new()
         .route(
             "/v1/blobs/{algorithm}/{hash}/{size}",
             get(get_blob).put(put_blob),
         )
+        // Innermost: what the handler reads, after decoding.
+        .layer(RequestBodyLimitLayer::new(limit))
+        .layer(RequestDecompressionLayer::new())
+        // Outermost: what crosses the wire. Decoding leaves this unbounded on
+        // its own -- a skippable frame is arbitrarily large and decodes to
+        // nothing, so a limit on decoded bytes never sees it.
+        .layer(RequestBodyLimitLayer::new(limit));
+    Router::new()
+        .route("/v1/status", get(status))
+        .route("/v1/capabilities", get(capabilities))
+        .merge(blobs)
         .route("/v1/blobs:missing", post(missing_blobs))
         .route("/v1/blobs:pack", post(pack_blobs))
         .route(
@@ -84,12 +100,6 @@ pub fn router(state: AppState) -> Router {
             get(get_action_manifest).put(put_action_manifest),
         )
         .route("/metrics", get(metrics))
-        .layer(RequestBodyLimitLayer::new(limit))
-        // Decompression sits outside the body limit, so the limit bounds the
-        // *decompressed* stream: a small compressed body cannot expand past it
-        // inside a handler. put_blob's own size check then cuts anything that
-        // exceeds its declared digest, so a zstd bomb buys an attacker nothing.
-        .layer(RequestDecompressionLayer::new())
         // Fastest: rustc artifacts still compress well below level 1's cost,
         // and a cache server's CPU is better spent serving than squeezing.
         .layer(CompressionLayer::new().quality(CompressionLevel::Fastest))
@@ -1265,6 +1275,121 @@ mod tests {
         let headers = response.headers().clone();
         let body = response.into_body().collect().await.unwrap().to_bytes();
         (headers, String::from_utf8(body.to_vec()).unwrap())
+    }
+
+    /// A zstd frame that decodes to almost nothing but is large on the wire.
+    ///
+    /// Skippable frames carry arbitrary bytes a decoder discards, so they are
+    /// the cheapest way to ask a server to read a lot and produce nothing.
+    fn skippable_frame(payload_bytes: usize) -> Vec<u8> {
+        let mut frame = Vec::with_capacity(payload_bytes + 8);
+        frame.extend_from_slice(&0x184D_2A50_u32.to_le_bytes());
+        frame.extend_from_slice(&(payload_bytes as u32).to_le_bytes());
+        frame.extend(std::iter::repeat_n(0_u8, payload_bytes));
+        frame
+    }
+
+    async fn app_with_blob_limit(max_blob_bytes: u64) -> (Router, tempfile::TempDir) {
+        let directory = tempfile::tempdir().unwrap();
+        let blobs = Arc::new(FilesystemStore::new(directory.path()).await.unwrap());
+        let metadata = Arc::new(MemoryMetadata::default());
+        let auth = Authorizer::new(None, None, true).await.unwrap();
+        (
+            router(AppState::new(blobs, metadata, auth, max_blob_bytes)),
+            directory,
+        )
+    }
+
+    #[tokio::test]
+    async fn json_routes_do_not_decompress_their_bodies() {
+        // Compression is scoped to blob uploads. These handlers buffer and
+        // parse the whole body before they authenticate anyone, so an
+        // unauthenticated caller must not be able to spend a few kilobytes to
+        // fill that buffer.
+        let (app, _directory) = app_with_blob_limit(1024 * 1024 * 1024).await;
+        let payload = serde_json::json!({"digests": []}).to_string();
+
+        // Control: uncompressed, the same body is understood.
+        let response = app
+            .clone()
+            .oneshot(request(
+                "POST",
+                "/v1/blobs:missing".into(),
+                Body::from(payload.clone()),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        // Compressed, it is not: the route never decodes, so the extractor
+        // sees zstd bytes and rejects them rather than expanding anything.
+        let compressed = zstd::encode_all(payload.as_bytes(), 0).unwrap();
+        let mut encoded = request("POST", "/v1/blobs:missing".into(), Body::from(compressed));
+        encoded
+            .headers_mut()
+            .insert(header::CONTENT_ENCODING, "zstd".parse().unwrap());
+        let response = app.oneshot(encoded).await.unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn json_routes_keep_axums_default_body_limit() {
+        // A generous blob allowance must not become a generous JSON allowance.
+        // Axum's 2 MB default is what bounds these; pinned here so raising the
+        // blob limit, or a change in that default, cannot loosen them quietly.
+        let (app, _directory) = app_with_blob_limit(1024 * 1024 * 1024).await;
+        let oversized = vec![b'a'; 4 * 1024 * 1024];
+
+        let response = app
+            .oneshot(request(
+                "POST",
+                "/v1/blobs:missing".into(),
+                Body::from(oversized),
+            ))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+    }
+
+    #[tokio::test]
+    async fn blob_uploads_bound_what_crosses_the_wire() {
+        // Decoding leaves the encoded stream unbounded on its own: a skippable
+        // frame is arbitrarily large and decodes to nothing, so a limit on
+        // decoded bytes never sees it and the connection reads until EOF.
+        let digest = digest(b"unused");
+        let uri = format!(
+            "/v1/blobs/{}/{}/{}",
+            digest.algorithm, digest.hash, digest.size
+        );
+
+        // Declared length: refused outright, without reading the body.
+        let (app, _directory) = app_with_blob_limit(64 * 1024).await;
+        let frame = skippable_frame(256 * 1024);
+        let length = frame.len();
+        let mut declared = request("PUT", uri.clone(), Body::from(frame.clone()));
+        declared
+            .headers_mut()
+            .insert(header::CONTENT_ENCODING, "zstd".parse().unwrap());
+        declared
+            .headers_mut()
+            .insert(header::CONTENT_LENGTH, length.to_string().parse().unwrap());
+        let response = app.oneshot(declared).await.unwrap();
+        assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+
+        // Chunked, which is how compressed uploads are actually sent, since
+        // the encoded length is unknown up front. The limit still cuts the
+        // stream; the decoder just reports the truncation it runs into before
+        // the limit's own error surfaces, so this is a 400 rather than a 413.
+        // Either way the server stops reading at the limit, which is the part
+        // that matters.
+        let (app, _directory) = app_with_blob_limit(64 * 1024).await;
+        let mut chunked = request("PUT", uri, Body::from(frame));
+        chunked
+            .headers_mut()
+            .insert(header::CONTENT_ENCODING, "zstd".parse().unwrap());
+        let response = app.oneshot(chunked).await.unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     }
 
     #[tokio::test]

--- a/src/server.rs
+++ b/src/server.rs
@@ -12,7 +12,12 @@ use sha2::Digest as _;
 use std::{collections::HashSet, io, sync::Arc, time::Instant};
 use tempfile::NamedTempFile;
 use tokio::io::AsyncWriteExt;
-use tower_http::{limit::RequestBodyLimitLayer, trace::TraceLayer};
+use tower_http::{
+    compression::{CompressionLayer, CompressionLevel},
+    decompression::RequestDecompressionLayer,
+    limit::RequestBodyLimitLayer,
+    trace::TraceLayer,
+};
 
 use crate::{
     auth::{Access, Authorizer},
@@ -80,6 +85,14 @@ pub fn router(state: AppState) -> Router {
         )
         .route("/metrics", get(metrics))
         .layer(RequestBodyLimitLayer::new(limit))
+        // Decompression sits outside the body limit, so the limit bounds the
+        // *decompressed* stream: a small compressed body cannot expand past it
+        // inside a handler. put_blob's own size check then cuts anything that
+        // exceeds its declared digest, so a zstd bomb buys an attacker nothing.
+        .layer(RequestDecompressionLayer::new())
+        // Fastest: rustc artifacts still compress well below level 1's cost,
+        // and a cache server's CPU is better spent serving than squeezing.
+        .layer(CompressionLayer::new().quality(CompressionLevel::Fastest))
         .layer(TraceLayer::new_for_http())
         .with_state(state)
 }
@@ -102,7 +115,7 @@ async fn capabilities(State(state): State<AppState>) -> impl IntoResponse {
     Json(serde_json::json!({
         "protocol":{"major":1,"minor":0},
         "digest_algorithms":["blake3","sha256"],
-        "compressors":["identity"],
+        "compressors":["identity","zstd"],
         "action_kinds":{
             "rustc":{"action_schema":1,"metadata_schema":1},
             "task":{"action_schema":1,"metadata_schema":1}
@@ -1252,6 +1265,62 @@ mod tests {
         let headers = response.headers().clone();
         let body = response.into_body().collect().await.unwrap().to_bytes();
         (headers, String::from_utf8(body.to_vec()).unwrap())
+    }
+
+    #[tokio::test]
+    async fn round_trips_zstd_compressed_transfers() {
+        let (app, _directory) = test_app().await;
+        // Long enough to clear the compression layer's minimum-size predicate,
+        // repetitive enough that compression visibly shrinks it.
+        let bytes = b"cached output ".repeat(64);
+        let digest = digest(&bytes);
+        let uri = format!(
+            "/v1/blobs/{}/{}/{}",
+            digest.algorithm, digest.hash, digest.size
+        );
+
+        // Upload compressed: the digest describes the *decompressed* content,
+        // which is what the handler must see after the decompression layer.
+        let compressed = zstd::encode_all(bytes.as_slice(), 0).unwrap();
+        assert!(compressed.len() < bytes.len());
+        let mut upload = request("PUT", uri.clone(), Body::from(compressed));
+        upload
+            .headers_mut()
+            .insert(header::CONTENT_ENCODING, "zstd".parse().unwrap());
+        let response = app.clone().oneshot(upload).await.unwrap();
+        assert_eq!(response.status(), StatusCode::CREATED);
+
+        // Download compressed: the body on the wire is zstd, and decoding it
+        // returns the exact stored bytes.
+        let mut download = request("GET", uri.clone(), Body::empty());
+        download
+            .headers_mut()
+            .insert(header::ACCEPT_ENCODING, "zstd".parse().unwrap());
+        let response = app.clone().oneshot(download).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response
+                .headers()
+                .get(header::CONTENT_ENCODING)
+                .and_then(|value| value.to_str().ok()),
+            Some("zstd")
+        );
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        assert!(body.len() < bytes.len());
+        assert_eq!(zstd::decode_all(&body[..]).unwrap(), bytes);
+
+        // A client that never asks for compression still gets identity bytes,
+        // which is what keeps already-released clients working unchanged.
+        let response = app
+            .oneshot(request("GET", uri, Body::empty()))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert!(response.headers().get(header::CONTENT_ENCODING).is_none());
+        assert_eq!(
+            response.into_body().collect().await.unwrap().to_bytes(),
+            bytes.as_slice()
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
The dogfood run on jdx/usage put a number on the remote path, and it is not flattering: a fresh runner restoring 206 actions spent **172s of cumulative blob transfer moving 1.3 GiB**, and the publishing build spent ~200s uploading 1.0 GiB — against a 124s from-scratch compile. The remote restore currently saves ~24% wall clock; nearly all of the shortfall is uncompressed bytes on the wire. rustc artifacts compress ~2.5–3× with zstd.

Client counterpart: [jdx/mr-boxington#22](https://github.com/jdx/mr-boxington/pull/22). Either side ships first safely — each is inert until the other arrives.

## What it does

At the HTTP layer, so nothing about the protocol changes — blob-pack frame format, media types, and protocol version all stay as they are:

- responses compress with zstd when the request's `Accept-Encoding` asks,
- blob uploads sent with `Content-Encoding: zstd` are decompressed before the handler,
- capabilities advertises `["identity","zstd"]` so clients can negotiate uploads.

A client that never asks gets identity bytes, so every released client keeps working unchanged.

## Where the layers sit, and why

My first version applied decompression to every route and claimed the body limit bounded the decompressed stream. Review caught it; both problems were reproduced as tests before being fixed.

**The encoded stream had no bound at all.** A zstd skippable frame is arbitrarily large and decodes to nothing, so a limit on decoded bytes never sees it and the connection reads until EOF. A 256 KiB frame against a 64 KiB limit was accepted. There is now an outer limit bounding the wire, with the decoded limit still inside it.

That limit reports differently by framing, which the test records rather than hides: with a declared `Content-Length` it is a flat 413, and chunked — how compressed uploads are actually sent, the encoded length being unknown up front — the limit cuts the stream and the decoder reports the truncation first, so it is a 400. Both stop reading at the limit.

**Decompression is now scoped to the blob route.** The JSON handlers buffer and parse their whole body before they authenticate anyone, so decoding there let an unauthenticated caller spend a few kilobytes to fill that buffer. Only blob uploads are ever compressed, so those routes now decode nothing at all — removing the amplification rather than bounding it.

Worth stating the size of that exposure accurately, because it is smaller than it looks: axum's own `DefaultBodyLimit` of 2 MB applies to `Json` extractors and is unaffected by the tower-http layer. Measured directly — 1 MiB decoded parses, 3 MiB is refused. The pre-auth ceiling was **2 MB, never `max_blob_bytes`**. A real amplification, bounded, not an OOM.

Compression level is `Fastest`: rustc artifacts compress well below even level 1's cost, and this server's CPU is better spent serving than squeezing.

## Tests

44 pass. Four are new and each pins something that could regress silently: the compressed round trip in both directions plus the identity fallback; that JSON routes reject a compressed body rather than expanding it; that the 2 MB JSON ceiling holds even with a 1 GiB blob limit; and that an oversized encoded stream is cut in both framings.

## Expected effect

rlibs compress ~2.5–3×, so the 1.3 GiB restore should move ~450–550 MiB — the difference between the remote being marginal and being worth it. Real numbers come from the dogfood job once the client side is released and its pinned `MBX_VERSION` is bumped.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*