### PR TITLE
ci: add zizmor workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
   deployment:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           persist-credentials: false
       - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
@@ -103,13 +103,13 @@ jobs:
     env:
       MBX_CACHE_TEST_DATABASE_URL: postgres://cache:cache@127.0.0.1:5432/cache
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           components: "rustfmt, clippy"
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@49a0bdc70d2e1b713ca9e2869b211fcce03d3c1c # v2
       - run: cargo fmt --check
       - run: cargo clippy --all-targets --all-features -- -D warnings
       - run: cargo test --all-features

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,20 @@
+name: zizmor
+on:
+  pull_request:
+    paths: [".github/workflows/**"]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2
+        with:
+          advanced-security: false
+          min-severity: high


### PR DESCRIPTION
Add a pinned zizmor workflow matching jdx/mise. It runs on pull requests that change GitHub Actions workflows, uses least-privilege permissions, and fails on high-severity findings.\n\nPin the existing checkout, Rust toolchain, and Rust cache actions so the new high-severity check passes.\n\nValidation:\n- zizmor --min-severity high .github/workflows\n- actionlint\n- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only changes: workflow pinning and a read-only security linter; no application or deployment logic is modified.
> 
> **Overview**
> Adds a **zizmor** workflow that runs on pull requests touching `.github/workflows/**`, scans workflows with `zizmor-action` (high severity and above), and uses minimal permissions (`contents: read` on the job, empty workflow-level permissions).
> 
> **Pins** previously floating action refs in `ci.yml`—`actions/checkout`, `dtolnay/rust-toolchain`, and `Swatinem/rust-cache`—to full commit SHAs with version comments so they satisfy the new high-severity supply-chain checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87ab7caf832edce85e9294ad56095f603172e2e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Improved CI security by pinning third-party automation components to immutable versions.
  * Added automated scanning for high-severity security issues in workflow configuration changes.
  * Restricted workflow permissions and disabled credential persistence during security checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->