### PR TITLE
fix(ci): restore releases after repository rename

### DIFF
--- a/.github/workflows/auto-merge-release.yml
+++ b/.github/workflows/auto-merge-release.yml
@@ -13,7 +13,8 @@ concurrency:
 
 jobs:
   merge:
-    if: github.repository == 'jdx/mbx-cache'
+    # The numeric repository ID survives renames, unlike github.repository.
+    if: github.repository_id == '1320413482'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -55,7 +56,7 @@ jobs:
           fi
 
           pr_number=$(gh pr list \
-            --repo jdx/mbx-cache \
+            --repo jdx/mr-boxington-cache \
             --base main \
             --state open \
             --limit 100 \
@@ -66,11 +67,11 @@ jobs:
             exit 0
           fi
 
-          body=$(gh pr view "$pr_number" --repo jdx/mbx-cache --json body --jq '.body // ""')
+          body=$(gh pr view "$pr_number" --repo jdx/mr-boxington-cache --json body --jq '.body // ""')
           if [ -z "$(tr -d '[:space:]' <<<"$body")" ]; then
             echo "Release PR #${pr_number} has an empty body; retrying later"
             exit 0
           fi
 
           echo "Release PR #${pr_number} is ready for the release window"
-          gh pr merge "$pr_number" --repo jdx/mbx-cache --squash --auto
+          gh pr merge "$pr_number" --repo jdx/mr-boxington-cache --squash --auto

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -10,7 +10,8 @@ permissions: {}
 jobs:
   release:
     name: Release
-    if: github.repository == 'jdx/mbx-cache'
+    # The numeric repository ID survives renames, unlike github.repository.
+    if: github.repository_id == '1320413482'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -187,7 +188,7 @@ jobs:
 
       - name: Deploy immutable image
         env:
-          MBX_CACHE_DEPLOY_GITHUB_WORKFLOW_REF: jdx/mbx-cache/.github/workflows/release-plz.yml@refs/heads/main
+          MBX_CACHE_DEPLOY_GITHUB_WORKFLOW_REF: jdx/mr-boxington-cache/.github/workflows/release-plz.yml@refs/heads/main
           MBX_CACHE_IMAGE: ${{ format('ghcr.io/jdx/mbx-cache@{0}', needs.image.outputs.digest) }}
           OVH_SSH_HOST: mise-cache-prod.tail13c301.ts.net
         run: |
@@ -198,7 +199,7 @@ jobs:
 
       - name: Qualify OIDC, PostgreSQL, and R2
         env:
-          CACHE_NAMESPACE: jdx/mbx-cache
+          CACHE_NAMESPACE: jdx/mr-boxington-cache
         run: |
           response=$(curl --fail --silent --show-error \
             --get \
@@ -249,7 +250,7 @@ jobs:
   release-pr:
     name: Release PR
     needs: release
-    if: github.repository == 'jdx/mbx-cache'
+    if: github.repository_id == '1320413482'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,8 @@ permissions: {}
 jobs:
   prepare:
     name: Prepare container image
-    if: github.repository == 'jdx/mbx-cache'
+    # The numeric repository ID survives renames, unlike github.repository.
+    if: github.repository_id == '1320413482'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:

--- a/deploy/ovh/README.md
+++ b/deploy/ovh/README.md
@@ -180,7 +180,7 @@ GitHub OIDC is configured with these server-enforced grants:
 - tag workflows for listed repositories: read-only;
 - pull-request workflows for listed repositories: read-only;
 - other push workflows for listed repositories: read-only; and
-- the exact `jdx/mbx-cache` production deployment workflow: read/write for
+- the exact `jdx/mr-boxington-cache` production deployment workflow: read/write for
   its isolated qualification namespace.
 
 Each trusted repository is paired with GitHub's stable numeric
@@ -280,8 +280,8 @@ resource first.
 | `mise-cache.json`, `mise-cache.yml` | Grafana provisioning on the host | Both files would be mounted, so Grafana would show the dashboard twice |
 
 One identifier could not be preserved: GitHub's OIDC subject embeds the
-repository, so the tokens this workflow presents now say `jdx/mbx-cache`. Any
-external trust that was pinned to `jdx/mise-cache` has to be updated on that
+repository, so the tokens this workflow presents now say `jdx/mr-boxington-cache`. Any
+external trust that was pinned to an earlier repository name has to be updated on that
 side — including the Tailscale trust credential used to join the tailnet, which
 is what fails if the tailnet step reports `failed to exchange JWT for access
 token`.

--- a/deploy/ovh/deploy.sh
+++ b/deploy/ovh/deploy.sh
@@ -57,9 +57,9 @@ if [[ $OVH_SSH_SOURCE_CIDR =~ [[:space:]] ]]; then
 fi
 
 trusted_repositories_file=${MBX_CACHE_GITHUB_REPOSITORIES_FILE:-$script_dir/trusted-repositories.json}
-deployment_repository=${MBX_CACHE_DEPLOY_GITHUB_REPOSITORY:-jdx/mbx-cache}
+deployment_repository=${MBX_CACHE_DEPLOY_GITHUB_REPOSITORY:-jdx/mr-boxington-cache}
 deployment_owner_id=${MBX_CACHE_DEPLOY_GITHUB_OWNER_ID:-216188}
-deployment_workflow_ref=${MBX_CACHE_DEPLOY_GITHUB_WORKFLOW_REF:-jdx/mbx-cache/.github/workflows/release-plz.yml@refs/heads/main}
+deployment_workflow_ref=${MBX_CACHE_DEPLOY_GITHUB_WORKFLOW_REF:-jdx/mr-boxington-cache/.github/workflows/release-plz.yml@refs/heads/main}
 ssh_user=${OVH_SSH_USER:-ubuntu}
 ssh_port=${OVH_SSH_PORT:-22}
 

--- a/deploy/ovh/test-deploy.sh
+++ b/deploy/ovh/test-deploy.sh
@@ -104,12 +104,12 @@ jq -e --argjson repositories "${MBX_CACHE_TEST_REPOSITORIES:?}" '
     ))
   )) and
   ($rules | any(
-    .claims.repository == "jdx/mbx-cache" and
+    .claims.repository == "jdx/mr-boxington-cache" and
     .claims.repository_owner_id == "216188" and
     .claims.environment == "production" and
-    .claims.workflow_ref == "jdx/mbx-cache/.github/workflows/release-plz.yml@refs/heads/main" and
-    .read == ["jdx/mbx-cache"] and
-    .write == ["jdx/mbx-cache"]
+    .claims.workflow_ref == "jdx/mr-boxington-cache/.github/workflows/release-plz.yml@refs/heads/main" and
+    .read == ["jdx/mr-boxington-cache"] and
+    .write == ["jdx/mr-boxington-cache"]
   ))
 ' <<<"$oidc_json" >/dev/null
 grep -Fq 'port = 2222' "$project_dir/mise.local.toml"


### PR DESCRIPTION
## Summary
- gate release workflows on the repository's stable numeric ID so future renames do not silently skip deployment
- update the production OIDC repository, workflow, and qualification namespace to `jdx/mr-boxington-cache`
- point release automation at the renamed repository while preserving the existing `ghcr.io/jdx/mbx-cache` image path

The production Tailscale trust credential must accept the renamed repository's OIDC subject, as documented in `deploy/ovh/README.md`.

## Validation
- `deploy/ovh/test-deploy.sh`
- `shellcheck deploy/ovh/deploy.sh deploy/ovh/test-deploy.sh`
- `actionlint`
- `zizmor --pedantic .github/workflows` (existing baseline findings only)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches production CI gates, OIDC deployment claims, and live deploy qualification; misconfiguration could block releases or tailnet join until Tailscale trust is updated.
> 
> **Overview**
> Restores release and deploy automation after the GitHub rename to **`jdx/mr-boxington-cache`** by gating **`auto-merge-release`**, **`release-plz`**, **`release`**, and **`release-pr`** on stable **`github.repository_id`** instead of the old **`github.repository`** string, so another rename will not skip jobs silently.
> 
> Release automation now targets **`jdx/mr-boxington-cache`** (`gh pr list` / merge in auto-merge; deploy env for workflow ref, OIDC qualification **`CACHE_NAMESPACE`**, and **`deploy.sh`** defaults). Container publishing still uses **`ghcr.io/jdx/mbx-cache`**.
> 
> Docs in **`deploy/ovh/README.md`** note that OIDC subjects now carry the new repo name and external trust (e.g. Tailscale) must be updated; **`test-deploy.sh`** asserts the matching production deployment OIDC rule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0eba12e5acc309dda292acd764a890b37e2265d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->