### PR TITLE
docs: link the user documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ commits, namespace isolation, typed action schemas, and streaming transfers.
 
 > This project is experimental and is not intended for others to use yet.
 
+User documentation lives at
+[mr-boxington.jdx.dev/cache-server](https://mr-boxington.jdx.dev/cache-server);
+this README carries the implementation and operations detail beyond it.
+
 ## Features
 
 - BLAKE3 and SHA-256 content-addressed storage


### PR DESCRIPTION
Follow-up to #41: points readers at the new [cache server page](https://mr-boxington.jdx.dev/cache-server) in the mr-boxington docs (jdx/mr-boxington#96), keeping this README as the implementation and operations reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only README change with no runtime or configuration impact.
> 
> **Overview**
> Adds a short note near the top of **README.md** pointing readers to the public user docs at [mr-boxington.jdx.dev/cache-server](https://mr-boxington.jdx.dev/cache-server), and states that this README remains the place for **implementation and operations** detail beyond that page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdff96cee236af9bb251b3676ca171da077accfb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->