### PR TITLE
ci: watch for advisories on a schedule

### DIFF
--- a/.github/workflows/advisories.yml
+++ b/.github/workflows/advisories.yml
@@ -39,6 +39,7 @@ jobs:
         if: steps.deny.outcome == 'failure'
         env:
           RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+          NOTIFY_FROM: ${{ secrets.NOTIFY_FROM }}
           NOTIFY_EMAIL: ${{ secrets.NOTIFY_EMAIL }}
           REPOSITORY: ${{ github.repository }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -46,13 +47,13 @@ jobs:
           # A missing secret must not masquerade as a clean audit, but it must
           # not hide the advisory either: warn, and let the failing step below
           # still turn the run red.
-          if [[ -z "$RESEND_API_KEY" || -z "$NOTIFY_EMAIL" ]]; then
-            echo "::warning::RESEND_API_KEY or NOTIFY_EMAIL is unset; skipping the advisory email."
+          if [[ -z "$RESEND_API_KEY" || -z "$NOTIFY_FROM" || -z "$NOTIFY_EMAIL" ]]; then
+            echo "::warning::a notification secret is unset; skipping the advisory email."
             exit 0
           fi
           # jq builds the payload so an advisory title can never break the JSON.
           payload="$(jq -n \
-            --arg from 'mbx advisories <mbx@en.dev>' \
+            --arg from "$NOTIFY_FROM" \
             --arg to "$NOTIFY_EMAIL" \
             --arg subject "cargo-deny found an advisory in ${REPOSITORY}" \
             --arg html "<p><code>cargo deny check advisories</code> failed on <strong>${REPOSITORY}</strong>.</p><p><a href=\"${RUN_URL}\">View the workflow run</a> for the advisory list.</p>" \

--- a/.github/workflows/advisories.yml
+++ b/.github/workflows/advisories.yml
@@ -1,0 +1,67 @@
+name: advisories
+
+# Nothing else in this repository watches the advisory database. CI runs on
+# push and pull request only, so an advisory published against a dependency of
+# the deployed server would wait for the next commit to surface. This run is
+# the standing watch for that case, and reports by email because a red
+# scheduled run nobody looks at is not a notification.
+on:
+  workflow_dispatch:
+  schedule:
+    # Daily, away from the top of the hour.
+    - cron: "37 7 * * *"
+
+concurrency:
+  group: advisories
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  advisories:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          persist-credentials: false
+
+      # Advisories only -- see the note in deny.toml.
+      - id: deny
+        continue-on-error: true
+        uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
+        with:
+          command: check advisories
+
+      - name: Email the advisory report
+        if: steps.deny.outcome == 'failure'
+        env:
+          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+          NOTIFY_EMAIL: ${{ secrets.NOTIFY_EMAIL }}
+          REPOSITORY: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          # A missing secret must not masquerade as a clean audit, but it must
+          # not hide the advisory either: warn, and let the failing step below
+          # still turn the run red.
+          if [[ -z "$RESEND_API_KEY" || -z "$NOTIFY_EMAIL" ]]; then
+            echo "::warning::RESEND_API_KEY or NOTIFY_EMAIL is unset; skipping the advisory email."
+            exit 0
+          fi
+          # jq builds the payload so an advisory title can never break the JSON.
+          payload="$(jq -n \
+            --arg from 'mbx advisories <mbx@en.dev>' \
+            --arg to "$NOTIFY_EMAIL" \
+            --arg subject "cargo-deny found an advisory in ${REPOSITORY}" \
+            --arg html "<p><code>cargo deny check advisories</code> failed on <strong>${REPOSITORY}</strong>.</p><p><a href=\"${RUN_URL}\">View the workflow run</a> for the advisory list.</p>" \
+            '{from: $from, to: [$to], subject: $subject, html: $html}')"
+          curl --fail-with-body -sS -X POST 'https://api.resend.com/emails' \
+            -H "Authorization: Bearer ${RESEND_API_KEY}" \
+            -H 'Content-Type: application/json' \
+            -d "$payload"
+
+      - name: Report the advisory
+        if: steps.deny.outcome == 'failure'
+        run: exit 1

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,16 @@
+# Advisory policy for the scheduled `cargo deny check advisories` run in
+# .github/workflows/advisories.yml. Licenses, bans, and sources are
+# deliberately not configured here: nothing runs those checks, and a policy
+# nobody enforces is worse than no policy.
+
+[advisories]
+yanked = "deny"
+ignore = [
+  # Marvin Attack: timing sidechannel in `rsa`. Reachable only from the
+  # `rsa` dev-dependency, which signs RSA keys for the OIDC test fixtures --
+  # it is not in the shipped server. Upstream has no patched release ("No
+  # safe upgrade is available"), so there is nothing to upgrade to and the
+  # alternative is dropping RSA coverage from the tests. Revisit when
+  # RustCrypto/RSA#626 lands a constant-time implementation.
+  "RUSTSEC-2023-0071",
+]


### PR DESCRIPTION
Nothing in this repository watched the advisory database. CI runs on push and pull request only, so an advisory published against a dependency of the deployed server waited for the next commit to surface. This adds a daily `cargo deny check advisories` run that emails on a finding, matching the watch added to `jdx/mr-boxington` and `jdx/mr-boxington-action`.

Reporting by email rather than only turning a run red follows [`jdx/ruby`](https://github.com/jdx/ruby)'s release notifier, and for the same reason — a red scheduled run nobody looks at is not a notification.

## What enabling it found

Wiring this up surfaced two live advisories, which is the point:

- **`RUSTSEC-2026-0258` — h2 unbounded empty DATA frames.** A real one, reaching the server through `aws-sdk-s3` and `aws-config`. This PR originally carried a lockfile bump for it, but [#44](https://github.com/jdx/mr-boxington-cache/pull/44) landed h2 0.4.16 on `main` independently — that is the patched release, so the commit was dropped on rebase rather than forcing a redundant 0.4.19.
- **`RUSTSEC-2023-0071` — Marvin Attack timing sidechannel in `rsa`.** Reachable only from the `rsa` dev-dependency that signs RSA keys for the OIDC test fixtures, so it is not in the shipped server. Upstream states plainly that no safe upgrade is available — there is no patched release to move to, and the alternative is dropping RSA coverage from the tests. **Ignored in `deny.toml`** with that rationale recorded, to revisit when [RustCrypto/RSA#626](https://github.com/RustCrypto/RSA/issues/626) lands a constant-time implementation.

`cargo deny check advisories` passes on this branch, so the watch starts green and only fires on something new.

## Notes

- `deny.toml` is new here and carries **advisory policy only**. Licenses, bans, and sources are left unconfigured deliberately: nothing runs those checks in this repo, and a policy nobody enforces is worse than no policy.
- No email address appears in the repository. All three of `RESEND_API_KEY`, `NOTIFY_FROM`, and `NOTIFY_EMAIL` come from secrets, and are now set on this repo. If any is unset the step warns and skips the mail while the run still goes red, so a secret problem can never look like a clean audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and advisory policy only; no runtime server or auth changes. Email uses secrets and jq-built JSON to avoid injection in payloads.
> 
> **Overview**
> Adds **standing RustSec coverage** outside push/PR CI: a daily GitHub Actions workflow runs `cargo deny check advisories` (plus manual `workflow_dispatch`), so new advisories against deployed dependencies can surface without waiting for the next commit.
> 
> On a failed check, the workflow **emails via Resend** (`RESEND_API_KEY`, `NOTIFY_FROM`, `NOTIFY_EMAIL`) with a link to the run, then **fails the job** so Actions stays red. Missing notification secrets only warn and skip mail; the advisory failure still reports.
> 
> Introduces **`deny.toml` scoped to advisories only** (`yanked = "deny"`), with an explicit ignore for `RUSTSEC-2023-0071` on the test-only `rsa` dev-dependency. License/ban/source policies are intentionally omitted because nothing enforces them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e44e3f9b0f4005a779e8221798016b3b7107f9d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added scheduled and on-demand security advisory checks.
  * Workflows now report detected advisories and send email notifications when configured.
  * Added policies to block vulnerable or withdrawn dependencies, with an approved exception for a development-only dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->