### PR TITLE
security: restrict OIDC writes and harden tree validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1299,9 +1299,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/README.md
+++ b/README.md
@@ -120,6 +120,17 @@ OIDC lets CI systems use short-lived identity tokens instead of stored cache sec
           "repository_owner_id": "216188"
         },
         "read": ["jdx/mise"],
+        "write": []
+      },
+      {
+        "claims": {
+          "repository": "jdx/mise",
+          "repository_owner_id": "216188",
+          "event_name": "push",
+          "ref_type": "branch",
+          "ref": "refs/heads/main"
+        },
+        "read": ["jdx/mise"],
         "write": ["jdx/mise"]
       }
     ]
@@ -127,9 +138,9 @@ OIDC lets CI systems use short-lived identity tokens instead of stored cache sec
 ]
 ```
 
-The server discovers the issuer's JWKS endpoint, verifies the signature, issuer, audience, expiry, not-before time, and subject, then applies the first matching authorization rule. Rules are alternatives; every claim within a rule must match exactly. A configured claim may be an array of accepted scalar values, and a token claim may itself be an array. Namespace grants use the same exact, `*`, and `prefix/*` forms as static tokens.
+The server discovers the issuer's JWKS endpoint, verifies the signature, issuer, audience, expiry, not-before time, and subject, then checks the matching authorization rules. Rules are alternatives; every claim within a rule must match exactly. A configured claim may be an array of accepted scalar values, and a token claim may itself be an array. Namespace grants use the same exact, `*`, and `prefix/*` forms as static tokens.
 
-Authorization is deny-by-default: every provider needs at least one audience and rule, and every rule must constrain at least one claim. Pin stable identity claims such as GitHub's numeric `repository_owner_id` alongside the repository name; add `ref`, `environment`, or other claims when only a narrower workflow identity should be able to write. Symmetric JWT algorithms are never accepted.
+Authorization is deny-by-default: every provider needs at least one audience and rule, and every rule must constrain at least one claim. Pin stable identity claims such as GitHub's numeric `repository_owner_id` alongside the repository name. GitHub Actions write rules should also require `event_name: "push"`, `ref_type: "branch"`, and an exact protected-branch `ref`; checking `ref` alone is unsafe because events such as `pull_request_target` use the base branch ref. Add `workflow_ref`, `job_workflow_ref`, or `environment` when only a narrower workflow identity should be able to write. Symmetric JWT algorithms are never accepted.
 
 Optional provider settings are:
 

--- a/deploy/ovh/deploy.sh
+++ b/deploy/ovh/deploy.sh
@@ -146,7 +146,7 @@ oidc_providers=$(jq -cn \
     rules: (
       (
         [$repositories[] as $entry | [
-          {claims: {repository: $entry.repository, repository_owner_id: $entry.repository_owner_id, ref: "refs/heads/main"}, read: [$entry.repository], write: [$entry.repository]},
+          {claims: {repository: $entry.repository, repository_owner_id: $entry.repository_owner_id, event_name: "push", ref_type: "branch", ref: "refs/heads/main"}, read: [$entry.repository], write: [$entry.repository]},
           {claims: {repository: $entry.repository, repository_owner_id: $entry.repository_owner_id, ref_type: "tag"}, read: [$entry.repository], write: []},
           {claims: {repository: $entry.repository, repository_owner_id: $entry.repository_owner_id, event_name: "pull_request"}, read: [$entry.repository], write: []},
           {claims: {repository: $entry.repository, repository_owner_id: $entry.repository_owner_id, event_name: "push"}, read: [$entry.repository], write: []}

--- a/deploy/ovh/test-deploy.sh
+++ b/deploy/ovh/test-deploy.sh
@@ -77,6 +77,8 @@ jq -e --argjson repositories "${MBX_CACHE_TEST_REPOSITORIES:?}" '
     ($rules | any(
       .claims.repository == $repository and
       .claims.repository_owner_id == "216188" and
+      .claims.event_name == "push" and
+      .claims.ref_type == "branch" and
       .claims.ref == "refs/heads/main" and
       .read == [$repository] and
       .write == [$repository]

--- a/src/server.rs
+++ b/src/server.rs
@@ -638,16 +638,30 @@ async fn require_blob(
 }
 
 async fn validate_tree(state: &AppState, namespace: &str, root: &Digest) -> Result<(), ApiError> {
-    let mut pending = vec![(root.clone(), HashSet::new())];
+    enum Visit {
+        Enter(Digest),
+        Exit(Digest),
+    }
+
+    let mut pending = vec![Visit::Enter(root.clone())];
+    let mut visiting = HashSet::new();
     let mut seen = HashSet::new();
-    while let Some((digest, mut ancestors)) = pending.pop() {
-        if !ancestors.insert(digest.clone()) {
-            return Err(ApiError::unprocessable("directory graph contains a cycle"));
-        }
-        if !seen.insert(digest.clone()) {
+    while let Some(visit) = pending.pop() {
+        let digest = match visit {
+            Visit::Exit(digest) => {
+                visiting.remove(&digest);
+                seen.insert(digest);
+                continue;
+            }
+            Visit::Enter(digest) => digest,
+        };
+        if seen.contains(&digest) {
             continue;
         }
-        if seen.len() > 100_000 {
+        if !visiting.insert(digest.clone()) {
+            return Err(ApiError::unprocessable("directory graph contains a cycle"));
+        }
+        if seen.len() + visiting.len() > 100_000 {
             return Err(ApiError::unprocessable("directory graph is too large"));
         }
         if digest.size > 16 * 1024 * 1024 {
@@ -687,11 +701,12 @@ async fn validate_tree(state: &AppState, namespace: &str, root: &Digest) -> Resu
         for file in directory.files {
             require_blob(state, namespace, &file.digest, "file blob").await?;
         }
+        pending.push(Visit::Exit(digest));
         pending.extend(
             directory
                 .directories
                 .into_iter()
-                .map(|node| (node.digest, ancestors.clone())),
+                .map(|node| Visit::Enter(node.digest)),
         );
     }
     Ok(())


### PR DESCRIPTION
## Summary

- require event_name=push, ref_type=branch, and refs/heads/main for production cache writes
- update the documented OIDC policy to separate broad reads from narrowly claimed writes
- replace per-child ancestor-set cloning with a linear-time DFS tree validator
- update h2 from 0.4.15 to 0.4.16 to resolve RUSTSEC-2026-0258

## Security impact

Default-branch refs from non-push events such as pull_request_target no longer qualify for write access. Authenticated writers also cannot drive directory validation into quadratic ancestor-set cloning.

## Validation

- cargo test --locked
- cargo clippy --all-features --all-targets --locked -- -D warnings
- deploy/ovh/test-deploy.sh
- shellcheck deploy/ovh/deploy.sh deploy/ovh/test-deploy.sh
- actionlint

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authentication policy for cache writes and fixes a DoS vector in action-result validation; misconfigured OIDC rules could block legitimate CI writes.
> 
> **Overview**
> **Tightens GitHub Actions OIDC write access** so protected-branch `ref` alone is no longer enough. Production and OVH deploy configs now require `event_name: "push"`, `ref_type: "branch"`, and an exact `refs/heads/main` ref for writes; broad read rules stay separate with empty `write`. README documents why `ref` alone is unsafe (e.g. `pull_request_target`).
> 
> **Hardens output-tree validation** in `validate_tree`: replaces per-child cloning of ancestor sets with an explicit DFS using `Enter`/`Exit` visits and `visiting`/`seen` sets, keeping cycle detection and the 100k node cap while avoiding quadratic work on deep trees.
> 
> **Dependency:** bumps `h2` to 0.4.16 in `Cargo.lock` (RUSTSEC-2026-0258).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1857a02d26fcb65fcba267c54669c6e32a0604d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->