### PR TITLE
fix(auth): restrict production cache writes to jdx

### DIFF
--- a/deploy/ovh/README.md
+++ b/deploy/ovh/README.md
@@ -176,7 +176,8 @@ role-password rotation.
 
 GitHub OIDC is configured with these server-enforced grants:
 
-- repositories listed in `trusted-repositories.json` on `main`: read/write;
+- repositories listed in `trusted-repositories.json` on `main`, when the
+  workflow run was initiated by the configured write actor: read/write;
 - tag workflows for listed repositories: read-only;
 - pull-request workflows for listed repositories: read-only;
 - other push workflows for listed repositories: read-only; and
@@ -187,7 +188,11 @@ Each trusted repository is paired with GitHub's stable numeric
 `repository_owner_id`; repository names must be unique. Edit the checked-in
 file to change the production allowlist, or set
 `MBX_CACHE_GITHUB_REPOSITORIES_FILE` to a different JSON file for another
-installation. Override
+installation. Write grants additionally require GitHub's stable numeric
+`actor_id`; it defaults to jdx's account ID, `216188`, and can be changed with
+`MBX_CACHE_GITHUB_WRITE_ACTOR_ID`. Read-only grants do not restrict the actor,
+so pull requests and automation initiated by other accounts can still consume
+trusted cache entries without publishing new ones. Override
 `MBX_CACHE_DEPLOY_GITHUB_REPOSITORY` and
 `MBX_CACHE_DEPLOY_GITHUB_OWNER_ID`, and
 `MBX_CACHE_DEPLOY_GITHUB_WORKFLOW_REF` together when deployment is managed by

--- a/deploy/ovh/README.md
+++ b/deploy/ovh/README.md
@@ -190,9 +190,12 @@ file to change the production allowlist, or set
 `MBX_CACHE_GITHUB_REPOSITORIES_FILE` to a different JSON file for another
 installation. Write grants additionally require GitHub's stable numeric
 `actor_id`; it defaults to jdx's account ID, `216188`, and can be changed with
-`MBX_CACHE_GITHUB_WRITE_ACTOR_ID`. Read-only grants do not restrict the actor,
-so pull requests and automation initiated by other accounts can still consume
-trusted cache entries without publishing new ones. Override
+`MBX_CACHE_GITHUB_WRITE_ACTOR_ID`. Write grants accept only the first attempt
+of a workflow run, because GitHub reruns retain the original actor's identity
+even when another account initiates the rerun. Read-only grants restrict
+neither the actor nor the run attempt, so pull requests, reruns, and automation
+initiated by other accounts can still consume trusted cache entries without
+publishing new ones. Override
 `MBX_CACHE_DEPLOY_GITHUB_REPOSITORY` and
 `MBX_CACHE_DEPLOY_GITHUB_OWNER_ID`, and
 `MBX_CACHE_DEPLOY_GITHUB_WORKFLOW_REF` together when deployment is managed by

--- a/deploy/ovh/deploy.sh
+++ b/deploy/ovh/deploy.sh
@@ -152,13 +152,13 @@ oidc_providers=$(jq -cn \
     rules: (
       (
         [$repositories[] as $entry | [
-          {claims: {repository: $entry.repository, repository_owner_id: $entry.repository_owner_id, actor_id: $write_actor_id, event_name: "push", ref_type: "branch", ref: "refs/heads/main"}, read: [$entry.repository], write: [$entry.repository]},
+          {claims: {repository: $entry.repository, repository_owner_id: $entry.repository_owner_id, actor_id: $write_actor_id, run_attempt: "1", event_name: "push", ref_type: "branch", ref: "refs/heads/main"}, read: [$entry.repository], write: [$entry.repository]},
           {claims: {repository: $entry.repository, repository_owner_id: $entry.repository_owner_id, ref_type: "tag"}, read: [$entry.repository], write: []},
           {claims: {repository: $entry.repository, repository_owner_id: $entry.repository_owner_id, event_name: "pull_request"}, read: [$entry.repository], write: []},
           {claims: {repository: $entry.repository, repository_owner_id: $entry.repository_owner_id, event_name: "push"}, read: [$entry.repository], write: []}
         ]] | add
       ) + [
-        {claims: {repository: $deployment_repository, repository_owner_id: $deployment_owner_id, actor_id: $write_actor_id, environment: "production", workflow_ref: $deployment_workflow_ref}, read: [$deployment_repository], write: [$deployment_repository]}
+        {claims: {repository: $deployment_repository, repository_owner_id: $deployment_owner_id, actor_id: $write_actor_id, run_attempt: "1", environment: "production", workflow_ref: $deployment_workflow_ref}, read: [$deployment_repository], write: [$deployment_repository]}
       ]
     )
   }]')

--- a/deploy/ovh/deploy.sh
+++ b/deploy/ovh/deploy.sh
@@ -57,6 +57,7 @@ if [[ $OVH_SSH_SOURCE_CIDR =~ [[:space:]] ]]; then
 fi
 
 trusted_repositories_file=${MBX_CACHE_GITHUB_REPOSITORIES_FILE:-$script_dir/trusted-repositories.json}
+write_actor_id=${MBX_CACHE_GITHUB_WRITE_ACTOR_ID:-216188}
 deployment_repository=${MBX_CACHE_DEPLOY_GITHUB_REPOSITORY:-jdx/mr-boxington-cache}
 deployment_owner_id=${MBX_CACHE_DEPLOY_GITHUB_OWNER_ID:-216188}
 deployment_workflow_ref=${MBX_CACHE_DEPLOY_GITHUB_WORKFLOW_REF:-jdx/mr-boxington-cache/.github/workflows/release-plz.yml@refs/heads/main}
@@ -85,6 +86,10 @@ if ! trusted_repositories=$(jq -ce '
 fi
 if [[ ! $deployment_repository =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
   echo "MBX_CACHE_DEPLOY_GITHUB_REPOSITORY must be an owner/repository name" >&2
+  exit 1
+fi
+if [[ ! $write_actor_id =~ ^[0-9]+$ ]]; then
+  echo "MBX_CACHE_GITHUB_WRITE_ACTOR_ID must be numeric" >&2
   exit 1
 fi
 if [[ ! $deployment_owner_id =~ ^[0-9]+$ ]]; then
@@ -136,6 +141,7 @@ fi
 
 oidc_providers=$(jq -cn \
   --arg audience "$cache_url" \
+  --arg write_actor_id "$write_actor_id" \
   --arg deployment_repository "$deployment_repository" \
   --arg deployment_owner_id "$deployment_owner_id" \
   --arg deployment_workflow_ref "$deployment_workflow_ref" \
@@ -146,13 +152,13 @@ oidc_providers=$(jq -cn \
     rules: (
       (
         [$repositories[] as $entry | [
-          {claims: {repository: $entry.repository, repository_owner_id: $entry.repository_owner_id, event_name: "push", ref_type: "branch", ref: "refs/heads/main"}, read: [$entry.repository], write: [$entry.repository]},
+          {claims: {repository: $entry.repository, repository_owner_id: $entry.repository_owner_id, actor_id: $write_actor_id, event_name: "push", ref_type: "branch", ref: "refs/heads/main"}, read: [$entry.repository], write: [$entry.repository]},
           {claims: {repository: $entry.repository, repository_owner_id: $entry.repository_owner_id, ref_type: "tag"}, read: [$entry.repository], write: []},
           {claims: {repository: $entry.repository, repository_owner_id: $entry.repository_owner_id, event_name: "pull_request"}, read: [$entry.repository], write: []},
           {claims: {repository: $entry.repository, repository_owner_id: $entry.repository_owner_id, event_name: "push"}, read: [$entry.repository], write: []}
         ]] | add
       ) + [
-        {claims: {repository: $deployment_repository, repository_owner_id: $deployment_owner_id, environment: "production", workflow_ref: $deployment_workflow_ref}, read: [$deployment_repository], write: [$deployment_repository]}
+        {claims: {repository: $deployment_repository, repository_owner_id: $deployment_owner_id, actor_id: $write_actor_id, environment: "production", workflow_ref: $deployment_workflow_ref}, read: [$deployment_repository], write: [$deployment_repository]}
       ]
     )
   }]')

--- a/deploy/ovh/test-deploy.sh
+++ b/deploy/ovh/test-deploy.sh
@@ -77,6 +77,7 @@ jq -e --argjson repositories "${MBX_CACHE_TEST_REPOSITORIES:?}" '
     ($rules | any(
       .claims.repository == $repository and
       .claims.repository_owner_id == "216188" and
+      .claims.actor_id == "216188" and
       .claims.event_name == "push" and
       .claims.ref_type == "branch" and
       .claims.ref == "refs/heads/main" and
@@ -108,6 +109,7 @@ jq -e --argjson repositories "${MBX_CACHE_TEST_REPOSITORIES:?}" '
   ($rules | any(
     .claims.repository == "jdx/mr-boxington-cache" and
     .claims.repository_owner_id == "216188" and
+    .claims.actor_id == "216188" and
     .claims.environment == "production" and
     .claims.workflow_ref == "jdx/mr-boxington-cache/.github/workflows/release-plz.yml@refs/heads/main" and
     .read == ["jdx/mr-boxington-cache"] and
@@ -150,6 +152,14 @@ if env "${common_env[@]}" \
   OVH_SSH_SOURCE_CIDR=203.0.113.10/32 \
   "$script_dir/deploy.sh" --dry-run >/dev/null 2>&1; then
   echo "deploy.sh accepted an image that was not pinned by digest" >&2
+  exit 1
+fi
+
+if env "${common_env[@]}" \
+  MBX_CACHE_GITHUB_WRITE_ACTOR_ID=not-numeric \
+  OVH_SSH_SOURCE_CIDR=203.0.113.10/32 \
+  "$script_dir/deploy.sh" --dry-run >/dev/null 2>&1; then
+  echo "deploy.sh accepted a non-numeric GitHub write actor ID" >&2
   exit 1
 fi
 

--- a/deploy/ovh/test-deploy.sh
+++ b/deploy/ovh/test-deploy.sh
@@ -177,6 +177,7 @@ fi
 env "${common_env[@]}" \
   MBX_CACHE_GITHUB_WRITE_ACTOR_ID=987654 \
   MBX_CACHE_TEST_WRITE_ACTOR_ID=987654 \
+  OVH_SSH_PORT=2222 \
   OVH_SSH_SOURCE_CIDR=203.0.113.10/32 \
   "$script_dir/deploy.sh" --dry-run
 

--- a/deploy/ovh/test-deploy.sh
+++ b/deploy/ovh/test-deploy.sh
@@ -64,7 +64,9 @@ grep -Fq "MBX_CACHE_GRAFANA_CONFIG_HASH=\"$grafana_config_hash\"" "$project_dir/
 grep -Fq 'AWS_ACCESS_KEY_ID="r2-access-key"' "$project_dir/runtime/cache.env"
 grep -Fq 'AWS_SECRET_ACCESS_KEY="r2-secret-key"' "$project_dir/runtime/cache.env"
 oidc_json=$(sed -n 's/^MBX_CACHE_OIDC_PROVIDERS_JSON=//p' "$project_dir/runtime/cache.env" | jq -c fromjson)
-jq -e --argjson repositories "${MBX_CACHE_TEST_REPOSITORIES:?}" '
+jq -e \
+  --argjson repositories "${MBX_CACHE_TEST_REPOSITORIES:?}" \
+  --arg write_actor_id "${MBX_CACHE_TEST_WRITE_ACTOR_ID:?}" '
   .[0].rules as $rules |
   # Four rules per trusted repository -- protected-main push, tag, pull
   # request, other push -- plus the single deployment rule. Both the list and
@@ -77,7 +79,8 @@ jq -e --argjson repositories "${MBX_CACHE_TEST_REPOSITORIES:?}" '
     ($rules | any(
       .claims.repository == $repository and
       .claims.repository_owner_id == "216188" and
-      .claims.actor_id == "216188" and
+      .claims.actor_id == $write_actor_id and
+      .claims.run_attempt == "1" and
       .claims.event_name == "push" and
       .claims.ref_type == "branch" and
       .claims.ref == "refs/heads/main" and
@@ -87,6 +90,8 @@ jq -e --argjson repositories "${MBX_CACHE_TEST_REPOSITORIES:?}" '
     ($rules | any(
       .claims.repository == $repository and
       .claims.repository_owner_id == "216188" and
+      .claims.actor_id == null and
+      .claims.run_attempt == null and
       .claims.ref_type == "tag" and
       .read == [$repository] and
       .write == []
@@ -94,6 +99,8 @@ jq -e --argjson repositories "${MBX_CACHE_TEST_REPOSITORIES:?}" '
     ($rules | any(
       .claims.repository == $repository and
       .claims.repository_owner_id == "216188" and
+      .claims.actor_id == null and
+      .claims.run_attempt == null and
       .claims.event_name == "pull_request" and
       .read == [$repository] and
       .write == []
@@ -101,6 +108,8 @@ jq -e --argjson repositories "${MBX_CACHE_TEST_REPOSITORIES:?}" '
     ($rules | any(
       .claims.repository == $repository and
       .claims.repository_owner_id == "216188" and
+      .claims.actor_id == null and
+      .claims.run_attempt == null and
       .claims.event_name == "push" and
       .read == [$repository] and
       .write == []
@@ -109,7 +118,8 @@ jq -e --argjson repositories "${MBX_CACHE_TEST_REPOSITORIES:?}" '
   ($rules | any(
     .claims.repository == "jdx/mr-boxington-cache" and
     .claims.repository_owner_id == "216188" and
-    .claims.actor_id == "216188" and
+    .claims.actor_id == $write_actor_id and
+    .claims.run_attempt == "1" and
     .claims.environment == "production" and
     .claims.workflow_ref == "jdx/mr-boxington-cache/.github/workflows/release-plz.yml@refs/heads/main" and
     .read == ["jdx/mr-boxington-cache"] and
@@ -132,6 +142,7 @@ trusted_repositories=$(jq -c 'map(.repository)' "$script_dir/trusted-repositorie
 common_env=(
   "CAPTURE_DIR=$test_root/capture"
   "MBX_CACHE_TEST_REPOSITORIES=$trusted_repositories"
+  "MBX_CACHE_TEST_WRITE_ACTOR_ID=216188"
   "MBX_CACHE_DATABASE_PASSWORD=database_password_123456"
   "MBX_CACHE_IMAGE=ghcr.io/jdx/mbx-cache@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
   "OVH_SSH_HOST=mbx-cache-prod.tailnet.example"
@@ -162,6 +173,12 @@ if env "${common_env[@]}" \
   echo "deploy.sh accepted a non-numeric GitHub write actor ID" >&2
   exit 1
 fi
+
+env "${common_env[@]}" \
+  MBX_CACHE_GITHUB_WRITE_ACTOR_ID=987654 \
+  MBX_CACHE_TEST_WRITE_ACTOR_ID=987654 \
+  OVH_SSH_SOURCE_CIDR=203.0.113.10/32 \
+  "$script_dir/deploy.sh" --dry-run
 
 invalid_repositories="$test_root/invalid-repositories.json"
 printf '%s\n' '[{"repository":"jdx/mise","repository_owner_id":"216188"},{"repository":"jdx/mise","repository_owner_id":"216188"}]' >"$invalid_repositories"


### PR DESCRIPTION
## Summary

- require GitHub OIDC actor_id 216188 for every production cache write grant
- keep read-only grants available to pull requests, tags, bots, and other actors
- validate and document the configurable write actor ID

## Tests

- bash -n deploy/ovh/deploy.sh deploy/ovh/test-deploy.sh
- deploy/ovh/test-deploy.sh
- mise x aqua:koalaman/shellcheck@0.11.0 -- shellcheck deploy/ovh/deploy.sh deploy/ovh/test-deploy.sh

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes production cache authentication and who can obtain write tokens via GitHub OIDC, a security-critical control path.
> 
> **Overview**
> Tightens OVH deploy **GitHub OIDC** rules so **write** access is no longer granted solely from trusted-repo `main` pushes or the production deployment workflow.
> 
> **Write** rules for protected `main` pushes and the `mr-boxington-cache` production workflow now require GitHub claim **`actor_id`** (default **216188**, overridable via `MBX_CACHE_GITHUB_WRITE_ACTOR_ID`) and **`run_attempt` "1"**, so reruns triggered by another account cannot publish cache entries. **Read-only** rules (tags, pull requests, other pushes) are unchanged and still omit actor/attempt checks.
> 
> `deploy.sh` validates the write actor ID as numeric and passes it into generated OIDC JSON; **README** documents the grant model. **`test-deploy.sh`** asserts the new claims, rejects non-numeric actor IDs, and dry-runs with a custom actor ID.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c1803e0766774ab5ea647f0d25f16cce7591fac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Strengthened trusted-repository write access by requiring workflows to be initiated by a configured GitHub actor.
  * Applied actor verification to protected branch updates and production deployments.
  * Added validation to reject invalid, non-numeric actor identifiers.
  * Read-only access remains available without actor restrictions.

* **Documentation**
  * Updated OVH deployment guidance with the new actor configuration and default setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->