### PR TITLE
ci: add final status job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,3 +113,21 @@ jobs:
       - run: cargo fmt --check
       - run: cargo clippy --all-targets --all-features -- -D warnings
       - run: cargo test --all-features
+
+  final:
+    permissions: {}
+    needs:
+      - deployment
+      - test
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    # Run on success or upstream failure but skip when the workflow is cancelled
+    # — `always()` would override `cancel-in-progress` and waste a runner.
+    if: ${{ !cancelled() }}
+    steps:
+      - name: Check job results
+        if: |
+          needs.deployment.result != 'success' ||
+          needs.test.result != 'success'
+        run: exit 1
+      - run: echo "All CI jobs completed successfully"


### PR DESCRIPTION
## Summary

- add a terminal CI job that depends on deployment and test
- fail the aggregate status when either required job fails
- skip the final job when the workflow is cancelled

## Validation

- `mise x actionlint@1.7.7 -- actionlint -shellcheck= .github/workflows/ci.yml`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes GitHub Actions orchestration; no application, security, or deployment runtime behavior is modified.
> 
> **Overview**
> Adds a **`final`** job at the end of the CI workflow that **depends on** `deployment` and `test`, so a single job can represent overall CI success for branch protection or status checks.
> 
> The job runs when the workflow is **not cancelled** (`!cancelled()`), avoiding wasted runners when `cancel-in-progress` cancels sibling jobs—unlike an `always()` condition. It uses **empty permissions** and a **1-minute** timeout. If either upstream job did not succeed, a step **exits 1**; otherwise it logs that all jobs completed successfully.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e5844a858506efe8d1cfd1ee5799aa0fc698ef9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->