### PR TITLE
fix(auth): allow trusted warm benchmark dispatches

### DIFF
--- a/deploy/ovh/README.md
+++ b/deploy/ovh/README.md
@@ -178,6 +178,8 @@ GitHub OIDC is configured with these server-enforced grants:
 
 - repositories listed in `trusted-repositories.json` on `main`, when the
   workflow run was initiated by the configured write actor: read/write;
+- each listed repository's exact `warm-cache-benchmark.yml` workflow when
+  manually dispatched by the configured write actor on `main`: read/write;
 - tag workflows for listed repositories: read-only;
 - pull-request workflows for listed repositories: read-only;
 - other push workflows for listed repositories: read-only; and

--- a/deploy/ovh/deploy.sh
+++ b/deploy/ovh/deploy.sh
@@ -153,6 +153,7 @@ oidc_providers=$(jq -cn \
       (
         [$repositories[] as $entry | [
           {claims: {repository: $entry.repository, repository_owner_id: $entry.repository_owner_id, actor_id: $write_actor_id, run_attempt: "1", event_name: "push", ref_type: "branch", ref: "refs/heads/main"}, read: [$entry.repository], write: [$entry.repository]},
+          {claims: {repository: $entry.repository, repository_owner_id: $entry.repository_owner_id, actor_id: $write_actor_id, run_attempt: "1", event_name: "workflow_dispatch", ref_type: "branch", ref: "refs/heads/main", workflow_ref: ($entry.repository + "/.github/workflows/warm-cache-benchmark.yml@refs/heads/main")}, read: [$entry.repository], write: [$entry.repository]},
           {claims: {repository: $entry.repository, repository_owner_id: $entry.repository_owner_id, ref_type: "tag"}, read: [$entry.repository], write: []},
           {claims: {repository: $entry.repository, repository_owner_id: $entry.repository_owner_id, event_name: "pull_request"}, read: [$entry.repository], write: []},
           {claims: {repository: $entry.repository, repository_owner_id: $entry.repository_owner_id, event_name: "push"}, read: [$entry.repository], write: []}

--- a/deploy/ovh/test-deploy.sh
+++ b/deploy/ovh/test-deploy.sh
@@ -68,13 +68,14 @@ jq -e \
   --argjson repositories "${MBX_CACHE_TEST_REPOSITORIES:?}" \
   --arg write_actor_id "${MBX_CACHE_TEST_WRITE_ACTOR_ID:?}" '
   .[0].rules as $rules |
-  # Four rules per trusted repository -- protected-main push, tag, pull
-  # request, other push -- plus the single deployment rule. Both the list and
-  # the count come from the allowlist the deploy just consumed, so adding a
+  # Five rules per trusted repository -- protected-main push, the exact warm
+  # benchmark dispatch, tag, pull request, and other push -- plus the single
+  # deployment rule. Both the list and the count come from the allowlist the
+  # deploy just consumed, so adding a
   # repository does not fail this on a restated name or a stale number. What
   # is still checked is that every configured repository got exactly those
-  # four rules and that nothing generated a rule beyond them.
-  ($rules | length == ($repositories | length) * 4 + 1) and
+  # five rules and that nothing generated a rule beyond them.
+  ($rules | length == ($repositories | length) * 5 + 1) and
   ($repositories | all(. as $repository |
     ($rules | any(
       .claims.repository == $repository and
@@ -84,6 +85,18 @@ jq -e \
       .claims.event_name == "push" and
       .claims.ref_type == "branch" and
       .claims.ref == "refs/heads/main" and
+      .read == [$repository] and
+      .write == [$repository]
+    )) and
+    ($rules | any(
+      .claims.repository == $repository and
+      .claims.repository_owner_id == "216188" and
+      .claims.actor_id == $write_actor_id and
+      .claims.run_attempt == "1" and
+      .claims.event_name == "workflow_dispatch" and
+      .claims.ref_type == "branch" and
+      .claims.ref == "refs/heads/main" and
+      .claims.workflow_ref == ($repository + "/.github/workflows/warm-cache-benchmark.yml@refs/heads/main") and
       .read == [$repository] and
       .write == [$repository]
     )) and


### PR DESCRIPTION
The warm cache benchmarks in hk and mise run through `workflow_dispatch`, but production OIDC currently authorizes only push, pull-request, and tag events. Their server requests therefore receive 403 and silently benchmark a cold local-only build.

Add a narrowly scoped read/write rule for each trusted repository that requires:

- the configured jdx actor ID
- the first run attempt
- `workflow_dispatch` on `refs/heads/main`
- the exact repository-local `warm-cache-benchmark.yml` workflow ref

This keeps arbitrary dispatch workflows and reruns denied while allowing the controlled seed/warm comparison.

Validated with `deploy/ovh/test-deploy.sh`, ShellCheck 0.11.0, and `git diff --check`.

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands production OIDC write grants for cache auth, but scoped to one workflow, one branch, one actor, and first attempt only.
> 
> **Overview**
> Trusted-repo warm cache benchmarks run via **manual `workflow_dispatch`**, but production GitHub OIDC only granted read/write on protected `main` **push**—benchmark jobs were getting **403** and measuring cold local builds instead of the shared cache.
> 
> This adds one **narrow read/write rule per allowlisted repository** in `deploy.sh`: configured write `actor_id`, first `run_attempt`, `workflow_dispatch` on `refs/heads/main`, and the exact `warm-cache-benchmark.yml` workflow ref. Other dispatches and reruns stay denied. **README** documents the grant; **test-deploy.sh** expects five rules per repo and asserts the new claims.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73fd470e88717acbfc8ba3312af0a82fdff8ee6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for manually running the warm-cache benchmark workflow on the main branch with the configured deployment permissions.

- **Documentation**
  - Updated the OVH deployment guide to document the workflow-specific permissions.

- **Tests**
  - Added validation for the new workflow permission rule and updated deployment rule-count checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->