### PR TITLE
fix action batch metadata latency

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Every option has a matching environment variable and CLI flag. Run `mbx-cache --
 | `MBX_CACHE_STORAGE` | `filesystem` | `filesystem` or `s3` |
 | `MBX_CACHE_DATA_DIR` | `/var/lib/mbx-cache` | Filesystem blob root |
 | `MBX_CACHE_DATABASE_URL` | `memory://` | PostgreSQL URL or development memory store |
+| `MBX_CACHE_DATABASE_MAX_CONNECTIONS` | `32` | Maximum concurrent PostgreSQL metadata connections |
 | `MBX_CACHE_S3_BUCKET` | — | Required for S3 storage |
 | `MBX_CACHE_S3_PREFIX` | `v1` | Object-key prefix |
 | `MBX_CACHE_S3_ENDPOINT` | AWS default | S3-compatible endpoint |

--- a/charts/mbx-cache/templates/deployment.yaml
+++ b/charts/mbx-cache/templates/deployment.yaml
@@ -22,6 +22,7 @@ spec:
           env:
             - {name: MBX_CACHE_STORAGE, value: {{ .Values.config.storage | quote }}}
             - {name: MBX_CACHE_DATABASE_URL, value: {{ required "config.databaseUrl is required" .Values.config.databaseUrl | quote }}}
+            - {name: MBX_CACHE_DATABASE_MAX_CONNECTIONS, value: {{ .Values.config.databaseMaxConnections | quote }}}
             - {name: MBX_CACHE_S3_BUCKET, value: {{ required "config.s3Bucket is required" .Values.config.s3Bucket | quote }}}
             - {name: MBX_CACHE_S3_PREFIX, value: {{ .Values.config.s3Prefix | quote }}}
             - {name: MBX_CACHE_S3_REGION, value: {{ .Values.config.s3Region | quote }}}

--- a/charts/mbx-cache/values.yaml
+++ b/charts/mbx-cache/values.yaml
@@ -11,6 +11,7 @@ resources:
 config:
   storage: s3
   databaseUrl: ""
+  databaseMaxConnections: 32
   s3Bucket: ""
   s3Prefix: v1
   s3Region: us-east-1

--- a/deploy/ovh/bootstrap/cache.env.example
+++ b/deploy/ovh/bootstrap/cache.env.example
@@ -1,5 +1,6 @@
 MBX_CACHE_STORAGE="s3"
 MBX_CACHE_DATABASE_URL="postgres://mise_cache:replace-with-a-url-safe-password@postgres/mise_cache"
+MBX_CACHE_DATABASE_MAX_CONNECTIONS="32"
 MBX_CACHE_S3_BUCKET="mise-cache-production"
 MBX_CACHE_S3_PREFIX="v1"
 MBX_CACHE_S3_ENDPOINT="https://example.r2.cloudflarestorage.com"

--- a/deploy/ovh/deploy.sh
+++ b/deploy/ovh/deploy.sh
@@ -213,6 +213,7 @@ write_dotenv() {
   write_dotenv MBX_CACHE_STORAGE s3
   write_dotenv MBX_CACHE_DATABASE_URL \
     "postgres://mise_cache:$MBX_CACHE_DATABASE_PASSWORD@postgres/mise_cache"
+  write_dotenv MBX_CACHE_DATABASE_MAX_CONNECTIONS 32
   write_dotenv MBX_CACHE_S3_BUCKET "$r2_bucket"
   write_dotenv MBX_CACHE_S3_PREFIX v1
   write_dotenv MBX_CACHE_S3_ENDPOINT "$r2_endpoint"

--- a/src/config.rs
+++ b/src/config.rs
@@ -28,6 +28,10 @@ pub struct Config {
     #[arg(long, env = "MBX_CACHE_DATABASE_URL", default_value = "memory://")]
     pub database_url: String,
 
+    /// Maximum concurrent PostgreSQL connections used for metadata requests.
+    #[arg(long, env = "MBX_CACHE_DATABASE_MAX_CONNECTIONS", default_value_t = 32)]
+    pub database_max_connections: u32,
+
     /// Sweep metadata older than this many days, then exit without serving.
     ///
     /// R2 expires the objects themselves through a lifecycle rule, which leaves

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,8 @@ async fn main() -> Result<()> {
         .json()
         .init();
 
-    let metadata = metadata::from_url(&config.database_url).await?;
+    let metadata =
+        metadata::from_url(&config.database_url, config.database_max_connections).await?;
     // A sweep is an operator action, not part of serving: do it and exit rather
     // than deleting from under a live server.
     if let Some(days) = config.sweep_metadata_older_than_days {

--- a/src/metadata/mod.rs
+++ b/src/metadata/mod.rs
@@ -117,10 +117,15 @@ pub trait MetadataStore: Send + Sync {
     }
 }
 
-pub async fn from_url(url: &str) -> anyhow::Result<std::sync::Arc<dyn MetadataStore>> {
+pub async fn from_url(
+    url: &str,
+    max_connections: u32,
+) -> anyhow::Result<std::sync::Arc<dyn MetadataStore>> {
     if url == "memory://" {
         Ok(std::sync::Arc::new(MemoryMetadata::default()))
     } else {
-        Ok(std::sync::Arc::new(PostgresMetadata::connect(url).await?))
+        Ok(std::sync::Arc::new(
+            PostgresMetadata::connect(url, max_connections).await?,
+        ))
     }
 }

--- a/src/metadata/postgres.rs
+++ b/src/metadata/postgres.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use sqlx::{PgPool, Row};
+use sqlx::{PgPool, Row, postgres::PgPoolOptions};
 
 use super::{CommitOutcome, ManifestCommitOutcome, ManifestRecord, MetadataStore, SweepOutcome};
 use crate::model::{ActionResult, Digest, TaskActionManifest};
@@ -15,8 +15,11 @@ pub struct PostgresMetadata {
 }
 
 impl PostgresMetadata {
-    pub async fn connect(url: &str) -> anyhow::Result<Self> {
-        let pool = PgPool::connect(url).await?;
+    pub async fn connect(url: &str, max_connections: u32) -> anyhow::Result<Self> {
+        let pool = PgPoolOptions::new()
+            .max_connections(max_connections)
+            .connect(url)
+            .await?;
         MIGRATOR.run(&pool).await?;
         Ok(Self { pool })
     }
@@ -230,17 +233,23 @@ impl MetadataStore for PostgresMetadata {
             .map(|(digest, _)| digest.hash.clone())
             .collect::<Vec<_>>();
         let sizes = actions.iter().map(|(_, size)| *size).collect::<Vec<_>>();
-        // The same join `visible_blobs` uses: one round trip for the whole
-        // request, and rows come back only for the actions this namespace holds.
+        // Keep this as one round trip, but make every requested digest an
+        // explicit primary-key probe. A join against the whole action-results
+        // relation can turn into a hash join as a namespace grows, scanning and
+        // decoding every cached row to answer a few hundred requested keys.
+        // The correlated scalar subquery is unique by the primary key and keeps
+        // the cost proportional to the request instead of the namespace.
         let rows = sqlx::query(
-            "SELECT results.result \
+            "SELECT ( \
+                 SELECT results.result \
+                 FROM action_results AS results \
+                 WHERE results.namespace = $1 \
+                   AND results.algorithm = requested.algorithm \
+                   AND results.hash = requested.hash \
+                   AND results.size = requested.size \
+             ) AS result \
              FROM UNNEST($2::text[], $3::text[], $4::bigint[]) WITH ORDINALITY \
                   AS requested(algorithm, hash, size, ordinality) \
-             JOIN action_results AS results \
-               ON results.algorithm = requested.algorithm \
-              AND results.hash = requested.hash \
-              AND results.size = requested.size \
-             WHERE results.namespace = $1 \
              ORDER BY requested.ordinality",
         )
         .bind(namespace)
@@ -250,7 +259,13 @@ impl MetadataStore for PostgresMetadata {
         .fetch_all(&self.pool)
         .await?;
         rows.into_iter()
-            .map(|row| serde_json::from_value(row.try_get("result")?).map_err(Into::into))
+            .filter_map(
+                |row| match row.try_get::<Option<serde_json::Value>, _>("result") {
+                    Ok(Some(result)) => Some(serde_json::from_value(result).map_err(Into::into)),
+                    Ok(None) => None,
+                    Err(error) => Some(Err(error.into())),
+                },
+            )
             .collect()
     }
 
@@ -340,7 +355,7 @@ mod tests {
     async fn store() -> Option<PostgresMetadata> {
         match std::env::var("MBX_CACHE_TEST_DATABASE_URL") {
             Ok(url) => Some(
-                PostgresMetadata::connect(&url)
+                PostgresMetadata::connect(&url, 4)
                     .await
                     .expect("the test database should accept connections"),
             ),


### PR DESCRIPTION
## Summary

- make the PostgreSQL metadata pool size configurable and raise the production default from 10 to 32
- keep batched action lookups proportional to the requested keys with explicit primary-key probes
- wire the pool setting through OVH and Helm deployments

The benchmark fleet can issue more than 10 concurrent metadata requests before blob-pack bookkeeping, which left batch requests waiting tens of seconds for a pool connection.

## Validation

- `cargo test --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- PostgreSQL batch integration test
- local 250k-row query benchmark (~1.1 ms for 256 requested keys)
- `deploy/ovh/test-deploy.sh`
- shellcheck and Helm lint/template

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hot-path PostgreSQL query plans and default pool sizing (more DB connections per replica); behavior should match prior batch semantics but load on Postgres may shift.
> 
> **Overview**
> Addresses **batch action-result metadata latency** by raising and making the PostgreSQL connection pool configurable, and by changing how batched lookups are queried.
> 
> **`MBX_CACHE_DATABASE_MAX_CONNECTIONS`** (CLI/env, default **32**) caps concurrent metadata connections. `PostgresMetadata` now builds the pool with `PgPoolOptions::max_connections` instead of sqlx’s smaller default, and startup passes the value through `metadata::from_url`. Helm, OVH deploy, and the README document the new setting.
> 
> For **`get_batch`**, the single-round-trip query no longer joins `UNNEST(...)` to all `action_results` rows in a namespace (which could hash-scan and decode the whole table). Each requested digest is resolved with a **correlated scalar subquery** keyed by namespace + algorithm/hash/size; missing keys are dropped via `NULL`/`filter_map`, preserving the same “only results this namespace holds” semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61ed50841f188f203c7e001d848fc86a4917764e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration for limiting concurrent PostgreSQL metadata connections, with a default of 32.
  * Helm and deployment configurations now support setting the connection limit.

* **Bug Fixes**
  * Improved metadata batch lookups to handle missing results without errors.
  * Optimized database queries for requested metadata records.

* **Documentation**
  * Documented the new connection-limit environment variable and its default value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->