### PR TITLE
reject empty database connection pools

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -29,7 +29,12 @@ pub struct Config {
     pub database_url: String,
 
     /// Maximum concurrent PostgreSQL connections used for metadata requests.
-    #[arg(long, env = "MBX_CACHE_DATABASE_MAX_CONNECTIONS", default_value_t = 32)]
+    #[arg(
+        long,
+        env = "MBX_CACHE_DATABASE_MAX_CONNECTIONS",
+        default_value_t = 32,
+        value_parser = clap::value_parser!(u32).range(1..)
+    )]
     pub database_max_connections: u32,
 
     /// Sweep metadata older than this many days, then exit without serving.
@@ -69,4 +74,14 @@ pub struct Config {
 
     #[arg(long, env = "MBX_CACHE_MAX_BLOB_BYTES", default_value_t = 5 * 1024 * 1024 * 1024_u64)]
     pub max_blob_bytes: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_an_empty_database_pool() {
+        assert!(Config::try_parse_from(["mbx-cache", "--database-max-connections", "0"]).is_err());
+    }
 }

--- a/src/metadata/postgres.rs
+++ b/src/metadata/postgres.rs
@@ -16,6 +16,10 @@ pub struct PostgresMetadata {
 
 impl PostgresMetadata {
     pub async fn connect(url: &str, max_connections: u32) -> anyhow::Result<Self> {
+        anyhow::ensure!(
+            max_connections > 0,
+            "database max connections must be at least 1"
+        );
         let pool = PgPoolOptions::new()
             .max_connections(max_connections)
             .connect(url)
@@ -370,6 +374,18 @@ mod tests {
                 None
             }
         }
+    }
+
+    #[tokio::test]
+    async fn an_empty_connection_pool_is_rejected_before_connecting() {
+        let error = PostgresMetadata::connect("postgres://unreachable.invalid/cache", 0)
+            .await
+            .err()
+            .expect("a zero-sized pool must be rejected");
+        assert_eq!(
+            error.to_string(),
+            "database max connections must be at least 1"
+        );
     }
 
     /// A namespace no other test shares, so one database serves them all.


### PR DESCRIPTION
## Summary

- reject `MBX_CACHE_DATABASE_MAX_CONNECTIONS=0` during argument parsing
- validate the same invariant defensively before constructing the PostgreSQL pool
- cover both paths with regression tests

Follow-up to the review feedback on #49, which was merged before the feedback fix reached its PR head.

## Validation

- `cargo test --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Startup/config validation only; no change to runtime metadata or query behavior when the pool size is valid.
> 
> **Overview**
> **`MBX_CACHE_DATABASE_MAX_CONNECTIONS` (and `--database-max-connections`) must be at least 1.** Values like `0` are now rejected at CLI/env parse time via a clap `value_parser` range on `database_max_connections`.
> 
> **`PostgresMetadata::connect` also enforces the same rule** before opening a pool, so misconfiguration cannot slip through if something bypasses config parsing.
> 
> Regression tests cover both paths: config parse failure for `"0"`, and connect returning `"database max connections must be at least 1"` without hitting the database.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71010b1ec954210664c81036dde7a205d4cd570e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->