### PR TITLE
docs: disclose current CI performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ commits, namespace isolation, typed action schemas, and streaming transfers.
 > consistently faster than
 > [`Swatinem/rust-cache`](https://github.com/Swatinem/rust-cache) on
 > GitHub-hosted runners. Benchmark end-to-end before replacing an existing CI
-> cache.
+> cache. Investigations, discussions, and pull requests to improve it are
+> welcome.
 
 User documentation lives at
 [mr-boxington.jdx.dev/cache-server](https://mr-boxington.jdx.dev/cache-server);

--- a/README.md
+++ b/README.md
@@ -17,6 +17,13 @@ commits, namespace isolation, typed action schemas, and streaming transfers.
 > infrastructure for nearby trusted runners, and benchmark end-to-end before
 > replacing an existing CI cache.
 
+The server may still be the better fit when fine-grained results need to be
+shared across worktrees, jobs, or several concurrent builds; when operators
+want namespace isolation, separate read/write grants, short-lived OIDC, and
+self-hosted control; or when one service should cache both mbx compilations
+and mise tasks. Those are operational and reuse advantages, not evidence of
+faster GitHub-hosted CI today.
+
 User documentation lives at
 [mr-boxington.jdx.dev/cache-server](https://mr-boxington.jdx.dev/cache-server);
 this README carries the implementation and operations detail beyond it.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,15 @@ commits, namespace isolation, typed action schemas, and streaming transfers.
 
 > This project is experimental and is not intended for others to use yet.
 
+> [!WARNING]
+> This server does not currently make mbx competitive with
+> [`Swatinem/rust-cache`](https://github.com/Swatinem/rust-cache) on
+> GitHub-hosted runners. In our warm-cache benchmarks, transferring the
+> server-backed action closure took longer than restoring a rust-cache target
+> archive and completing the build. Treat the server as experimental
+> infrastructure for nearby trusted runners, and benchmark end-to-end before
+> replacing an existing CI cache.
+
 User documentation lives at
 [mr-boxington.jdx.dev/cache-server](https://mr-boxington.jdx.dev/cache-server);
 this README carries the implementation and operations detail beyond it.

--- a/README.md
+++ b/README.md
@@ -9,20 +9,11 @@ commits, namespace isolation, typed action schemas, and streaming transfers.
 > This project is experimental and is not intended for others to use yet.
 
 > [!WARNING]
-> This server does not currently make mbx competitive with
+> Remote caching works and is actively improving, but does not yet make mbx
+> consistently faster than
 > [`Swatinem/rust-cache`](https://github.com/Swatinem/rust-cache) on
-> GitHub-hosted runners. In our warm-cache benchmarks, transferring the
-> server-backed action closure took longer than restoring a rust-cache target
-> archive and completing the build. Treat the server as experimental
-> infrastructure for nearby trusted runners, and benchmark end-to-end before
-> replacing an existing CI cache.
-
-The server may still be the better fit when fine-grained results need to be
-shared across worktrees, jobs, or several concurrent builds; when operators
-want namespace isolation, separate read/write grants, short-lived OIDC, and
-self-hosted control; or when one service should cache both mbx compilations
-and mise tasks. Those are operational and reuse advantages, not evidence of
-faster GitHub-hosted CI today.
+> GitHub-hosted runners. Benchmark end-to-end before replacing an existing CI
+> cache.
 
 User documentation lives at
 [mr-boxington.jdx.dev/cache-server](https://mr-boxington.jdx.dev/cache-server);


### PR DESCRIPTION
## Summary
- warn that the experimental server is not currently competitive with rust-cache in the measured GitHub-hosted runner workflow
- scope it to experimental use with nearby trusted runners and require end-to-end benchmarking
- explain the operational reasons it may still fit: granular sharing, namespace isolation, read/write grants, OIDC, self-hosted control, and shared mbx/mise caching

## Evidence
- server-backed hk: https://github.com/jdx/hk/actions/runs/33395159164
- GitHub-backed comparison for context: https://github.com/jdx/hk/actions/runs/33439934246

## Validation
- `git diff --check`

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> README-only disclosure with no changes to server code, auth, or deployment behavior.
> 
> **Overview**
> Adds a prominent **GitHub warning callout** in `README.md` right after the existing experimental notice.
> 
> The new text states that remote caching **works and is improving**, but **does not yet consistently outperform** [`Swatinem/rust-cache`](https://github.com/Swatinem/rust-cache) on **GitHub-hosted runners**. It tells adopters to **benchmark end-to-end** before swapping an existing CI cache, and invites issues and PRs to improve performance.
> 
> No runtime, API, or configuration behavior changes—**documentation only**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb27ebdbc06ff7e182695e6fe3eacab17214718c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->