### PR TITLE
fix: accept rustc linker identities

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -104,6 +104,8 @@ pub struct RustcAction {
     pub arguments: Vec<String>,
     pub environment: BTreeMap<String, Option<String>>,
     pub inputs: Vec<RustcInput>,
+    #[serde(default)]
+    pub linker: Option<RustcLinkerIdentity>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -121,6 +123,20 @@ pub struct RustcInput {
     /// Identifies local input content for the action key. This is not a CAS
     /// reference: compiler source inputs are never uploaded to the service.
     pub digest: Digest,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RustcLinkerIdentity {
+    pub driver: String,
+    pub driver_version: String,
+    pub linker_version: String,
+    #[serde(default)]
+    pub crt_objects: BTreeMap<String, Digest>,
+    #[serde(default)]
+    pub sdk: Option<String>,
+    #[serde(default)]
+    pub deployment_target: Option<String>,
 }
 
 fn valid_string(value: &str) -> bool {
@@ -221,6 +237,10 @@ impl RustcAction {
                 .inputs
                 .iter()
                 .all(|input| input.validate() && input_paths.insert(&input.path))
+            && self
+                .linker
+                .as_ref()
+                .is_none_or(RustcLinkerIdentity::validate)
     }
 }
 
@@ -235,6 +255,25 @@ impl RustcCompiler {
 impl RustcInput {
     fn validate(&self) -> bool {
         valid_normalized_path(&self.path) && self.digest.validate().is_ok()
+    }
+}
+
+impl RustcLinkerIdentity {
+    fn validate(&self) -> bool {
+        [&self.driver, &self.driver_version, &self.linker_version]
+            .into_iter()
+            .all(|value| !value.is_empty() && valid_string(value))
+            && self.crt_objects.iter().all(|(name, digest)| {
+                !name.is_empty() && valid_string(name) && digest.validate().is_ok()
+            })
+            && self
+                .sdk
+                .as_deref()
+                .is_none_or(|value| !value.is_empty() && valid_string(value))
+            && self
+                .deployment_target
+                .as_deref()
+                .is_none_or(|value| !value.is_empty() && valid_string(value))
     }
 }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -2476,6 +2476,50 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn publishes_native_link_results_without_uploading_linker_inputs() {
+        let (app, _directory) = test_app().await;
+        // Linker identity digests key host CRT inputs; like source-input
+        // digests, they are not remote CAS references.
+        let source = digest(b"fn main() {}\n");
+        let crt = digest(b"host crt object");
+        let mut action: serde_json::Value =
+            serde_json::from_slice(&rustc_action(&source, 1)).unwrap();
+        action["linker"] = serde_json::json!({
+            "crt_objects":{"crt1.o":crt},
+            "deployment_target":null,
+            "driver":"/usr/bin/cc",
+            "driver_version":"cc 15.2.0",
+            "linker_version":"GNU ld 2.45",
+            "sdk":null
+        });
+        let action = upload_blob(&app, &canonical(action)).await;
+        let stdout = upload_blob(&app, b"").await;
+        let stderr = upload_blob(&app, b"linker diagnostic\n").await;
+        let metadata = upload_blob(&app, &rustc_metadata(&stdout, &stderr, 1)).await;
+        let executable = upload_blob(&app, b"linked executable").await;
+        let output_root = upload_blob(&app, &output_directory(&executable)).await;
+        let result_uri = format!(
+            "/v1/action-results/{}/{}/{}",
+            action.algorithm, action.hash, action.size
+        );
+        let body = serde_json::to_vec(&ActionResult {
+            action,
+            metadata: Some(metadata),
+            output_root: Some(output_root),
+            version: 1,
+        })
+        .unwrap();
+
+        assert_eq!(
+            app.oneshot(request("PUT", result_uri, Body::from(body)))
+                .await
+                .unwrap()
+                .status(),
+            StatusCode::CREATED
+        );
+    }
+
+    #[tokio::test]
     async fn rejects_incomplete_rustc_results() {
         let (app, _directory) = test_app().await;
         let source = digest(b"pub fn widget() {}\n");


### PR DESCRIPTION
## Summary

- accept the optional native-linker identity emitted by mbx 1.3.1 and newer
- validate linker driver, CRT digest, SDK, and deployment-target fields
- keep CRT digests as action-key inputs rather than requiring them in the remote CAS
- cover native-link action-result publication with a regression test

## Context

Production builds using mbx 1.3.2 were receiving HTTP 422 responses when publishing native-link action results. The client added the optional linker field while the server still rejected it as unknown, preventing those results from warming the cache.

## Validation

- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all-features

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema extension with strict validation and a regression test; no changes to auth, storage, or existing actions without `linker`.
> 
> **Overview**
> Fixes **422 rejections** when newer mbx clients publish native-link rustc action results that include an optional **`linker`** block on the action descriptor.
> 
> **`RustcAction`** now deserializes an optional **`RustcLinkerIdentity`** (driver, versions, **`crt_objects`**, optional SDK / deployment target) and validates those fields when present. CRT object digests are treated like **source-input digests**—they participate in the action key only and are **not** required as uploaded CAS blobs when committing results.
> 
> A server integration test asserts a rustc result with linker metadata and CRT digests **not** in the cache still publishes successfully.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0787329a106bf16c46db176e7994943954dd7041. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Rust compilation actions can now include linker identity details, including driver and linker versions, SDK, deployment target, and CRT objects.
  * Linker metadata is validated to ensure it contains valid values and digests.
  * Results can be published successfully when linker inputs are referenced but not uploaded as separate artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->