### PR TITLE
infra: configure Azure Terraform state backend

### DIFF
--- a/deploy/azure/README.md
+++ b/deploy/azure/README.md
@@ -16,7 +16,8 @@ All new resources use the `mbx-cache` name. The public endpoint is
   virtual machines, role assignments, and storage accounts;
 - Azure CLI, Terraform 1.8 or newer, mise 2026.8.2 or newer, `curl`, `jq`,
   `ssh`, and `tailscale`;
-- a remote encrypted Terraform backend for production state;
+- access to the `mbxcachetfstate` Azure Storage account used by the checked-in
+  remote backend;
 - an SSH public key; and
 - a published mbx-cache image pinned by digest.
 
@@ -39,8 +40,10 @@ terraform plan
 terraform apply
 ```
 
-Keep production state in a remote encrypted backend. Local state and
-`terraform.tfvars` are ignored by Git.
+Production state is encrypted at rest in the private `tfstate` container of
+the `mbxcachetfstate` Azure Storage account. The backend authenticates with
+Microsoft Entra ID; operators need `Storage Blob Data Contributor` access to
+that container. Local state and `terraform.tfvars` are ignored by Git.
 
 For initial setup only, set `admin_source_cidr` to the operator's public `/32`.
 Terraform otherwise exposes only HTTP and HTTPS. The host firewall independently

--- a/deploy/azure/terraform/versions.tf
+++ b/deploy/azure/terraform/versions.tf
@@ -1,6 +1,14 @@
 terraform {
   required_version = ">= 1.8.0"
 
+  backend "azurerm" {
+    resource_group_name  = "mbx-cache-terraform"
+    storage_account_name = "mbxcachetfstate"
+    container_name       = "tfstate"
+    key                  = "production.tfstate"
+    use_azuread_auth     = true
+  }
+
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"


### PR DESCRIPTION
## Summary

- point the Azure production Terraform at the dedicated private state container
- use Microsoft Entra ID instead of embedding a storage key
- document the required data-plane access

## Validation

- `terraform fmt -check`
- `terraform init -backend=false -input=false`
- `terraform validate`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes where and how production Terraform state is stored and authenticated; misconfiguration or missing RBAC can block deploys or target the wrong state.
> 
> **Overview**
> **Pins Azure production Terraform** to a checked-in `azurerm` backend: state lives at `production.tfstate` in the private `tfstate` container on storage account `mbxcachetfstate` (resource group `mbx-cache-terraform`).
> 
> **Authentication for state** uses Microsoft Entra ID (`use_azuread_auth = true`) instead of a storage account key.
> 
> **README updates** replace generic remote-backend notes with that account as a prerequisite and spell out that operators need **Storage Blob Data Contributor** on the state container to run `terraform init` / apply.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd424b8dcd67e74a28e084cf21932db575f87d8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->