### PR TITLE
fix: qualify Azure deploy reruns

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -167,6 +167,7 @@ jobs:
 
       - name: Deploy immutable image
         env:
+          MBX_CACHE_DEPLOY_GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
           MBX_CACHE_DEPLOY_GITHUB_WORKFLOW_REF: jdx/mr-boxington-cache/.github/workflows/release-plz.yml@refs/heads/main
           MBX_CACHE_IMAGE: ${{ format('ghcr.io/jdx/mbx-cache@{0}', needs.image.outputs.digest) }}
         run: |

--- a/deploy/azure/deploy.sh
+++ b/deploy/azure/deploy.sh
@@ -59,6 +59,7 @@ write_actor_id=${MBX_CACHE_GITHUB_WRITE_ACTOR_ID:-216188}
 deployment_repository=${MBX_CACHE_DEPLOY_GITHUB_REPOSITORY:-jdx/mr-boxington-cache}
 deployment_owner_id=${MBX_CACHE_DEPLOY_GITHUB_OWNER_ID:-216188}
 deployment_workflow_ref=${MBX_CACHE_DEPLOY_GITHUB_WORKFLOW_REF:-jdx/mr-boxington-cache/.github/workflows/release-plz.yml@refs/heads/main}
+deployment_run_attempt=${MBX_CACHE_DEPLOY_GITHUB_RUN_ATTEMPT:-1}
 ssh_user=${AZURE_SSH_USER:-azureuser}
 ssh_port=${AZURE_SSH_PORT:-22}
 storage_container=${AZURE_STORAGE_CONTAINER:-cache}
@@ -94,6 +95,10 @@ if [[ ! $write_actor_id =~ ^[0-9]+$ ]]; then
 fi
 if [[ ! $deployment_owner_id =~ ^[0-9]+$ ]]; then
   echo "MBX_CACHE_DEPLOY_GITHUB_OWNER_ID must be numeric" >&2
+  exit 1
+fi
+if [[ ! $deployment_run_attempt =~ ^[1-9][0-9]*$ ]]; then
+  echo "MBX_CACHE_DEPLOY_GITHUB_RUN_ATTEMPT must be a positive integer" >&2
   exit 1
 fi
 if [[ ! $deployment_workflow_ref =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/[.]github/workflows/[A-Za-z0-9_.-]+[.]ya?ml@refs/heads/[A-Za-z0-9_./-]+$ ]]; then
@@ -145,6 +150,7 @@ oidc_providers=$(jq -cn \
   --arg deployment_repository "$deployment_repository" \
   --arg deployment_owner_id "$deployment_owner_id" \
   --arg deployment_workflow_ref "$deployment_workflow_ref" \
+  --arg deployment_run_attempt "$deployment_run_attempt" \
   --argjson repositories "$trusted_repositories" \
   '[{
     issuer: "https://token.actions.githubusercontent.com",
@@ -159,7 +165,7 @@ oidc_providers=$(jq -cn \
           {claims: {repository: $entry.repository, repository_owner_id: $entry.repository_owner_id, event_name: "push"}, read: [$entry.repository], write: []}
         ]] | add
       ) + [
-        {claims: {repository: $deployment_repository, repository_owner_id: $deployment_owner_id, actor_id: $write_actor_id, run_attempt: "1", environment: "production", workflow_ref: $deployment_workflow_ref}, read: [$deployment_repository], write: [$deployment_repository]}
+        {claims: {repository: $deployment_repository, repository_owner_id: $deployment_owner_id, actor_id: $write_actor_id, run_attempt: $deployment_run_attempt, environment: "production", workflow_ref: $deployment_workflow_ref}, read: [$deployment_repository], write: [$deployment_repository]}
       ]
     )
   }]')

--- a/deploy/azure/test-deploy.sh
+++ b/deploy/azure/test-deploy.sh
@@ -59,6 +59,7 @@ grep -Fq 'MBX_CACHE_AZURE_CREDENTIAL_TYPE="managed_identity"' "$project_dir/runt
 oidc_json=$(sed -n 's/^MBX_CACHE_OIDC_PROVIDERS_JSON=//p' "$project_dir/runtime/cache.env" | jq -c fromjson)
 jq -e \
   --argjson repositories "${MBX_CACHE_TEST_REPOSITORIES:?}" \
+  --arg deployment_run_attempt "${MBX_CACHE_TEST_DEPLOY_RUN_ATTEMPT:?}" \
   --arg write_actor_id "${MBX_CACHE_TEST_WRITE_ACTOR_ID:?}" '
   .[0].rules as $rules |
   # Five rules per trusted repository -- protected-main push, the exact warm
@@ -125,7 +126,7 @@ jq -e \
     .claims.repository == "jdx/mr-boxington-cache" and
     .claims.repository_owner_id == "216188" and
     .claims.actor_id == $write_actor_id and
-    .claims.run_attempt == "1" and
+    .claims.run_attempt == $deployment_run_attempt and
     .claims.environment == "production" and
     .claims.workflow_ref == "jdx/mr-boxington-cache/.github/workflows/release-plz.yml@refs/heads/main" and
     .read == ["jdx/mr-boxington-cache"] and
@@ -148,8 +149,10 @@ trusted_repositories=$(jq -c 'map(.repository)' "$script_dir/trusted-repositorie
 common_env=(
   "CAPTURE_DIR=$test_root/capture"
   "MBX_CACHE_TEST_REPOSITORIES=$trusted_repositories"
+  "MBX_CACHE_TEST_DEPLOY_RUN_ATTEMPT=4"
   "MBX_CACHE_TEST_WRITE_ACTOR_ID=216188"
   "MBX_CACHE_DATABASE_PASSWORD=database_password_123456"
+  "MBX_CACHE_DEPLOY_GITHUB_RUN_ATTEMPT=4"
   "MBX_CACHE_IMAGE=ghcr.io/jdx/mbx-cache@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
   "AZURE_SSH_HOST=mbx-cache-prod.tailnet.example"
   "AZURE_STORAGE_ACCOUNT=mbxcachetest"
@@ -176,6 +179,14 @@ if env "${common_env[@]}" \
   AZURE_SSH_SOURCE_CIDR=203.0.113.10/32 \
   "$script_dir/deploy.sh" --dry-run >/dev/null 2>&1; then
   echo "deploy.sh accepted a non-numeric GitHub write actor ID" >&2
+  exit 1
+fi
+
+if env "${common_env[@]}" \
+  MBX_CACHE_DEPLOY_GITHUB_RUN_ATTEMPT=zero \
+  AZURE_SSH_SOURCE_CIDR=203.0.113.10/32 \
+  "$script_dir/deploy.sh" --dry-run >/dev/null 2>&1; then
+  echo "deploy.sh accepted an invalid GitHub run attempt" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

- pass the current GitHub Actions run attempt into the deployed OIDC policy
- validate the attempt value before generating cache authorization rules
- cover rerun attempts and invalid input in the deployment test

## Verification

- `shellcheck deploy/azure/deploy.sh deploy/azure/test-deploy.sh`
- `deploy/azure/test-deploy.sh`
- `git diff --check`

The production service deployed successfully, but its qualification step returned 403 because rerun attempt 4 was checked against a policy hardcoded to attempt 1.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production cache authorization rules for the deploy workflow; misconfiguration could block deploys or qualification, but scope is limited to the deployment OIDC claim and includes validation and tests.
> 
> **Overview**
> Fixes production deploy qualification **403s on workflow reruns** by binding the deployed OIDC rule’s `run_attempt` claim to the current Actions run instead of always `"1"`.
> 
> The **release-plz** deploy step now sets `MBX_CACHE_DEPLOY_GITHUB_RUN_ATTEMPT` from `github.run_attempt`. **deploy.sh** reads that variable (default `1`), validates it as a positive integer, and injects it into the production deployment OIDC rule in `MBX_CACHE_OIDC_PROVIDERS_JSON`. Trusted-repository rules still use attempt `1` as before.
> 
> **test-deploy.sh** asserts the deployment rule matches a configured attempt (e.g. `4`) and rejects invalid values like `zero`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f27e556416dc5227c549c29878ccf2d72521aca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Azure deployments now correctly support repeated GitHub Actions run attempts.
  * Deployment validation accepts the current run attempt while rejecting invalid values.
* **Tests**
  * Added coverage for dynamic run-attempt handling and invalid deployment run attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->