### PR TITLE
fix: accept cc and build-script cache actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ Servers advertising `features.blob_pack_uploads` accept the same framing in the 
 
 Servers advertising `features.action_batch` answer `POST /v1/action-results:batch`, which takes the same digest-list JSON as `blobs:missing` and returns `application/vnd.mbx.cache-action-result-batch.v1+json`. The response carries only the results this namespace holds, in no particular order and at most once each, so clients bind each record to its request by the action digest inside it rather than by position. The request is bounded by `limits.max_batch_items`.
 
-`GET /v1/capabilities` advertises the action kinds and exact schema versions accepted by the server. Action-result keys use BLAKE3. Version 1 accepts task and rustc action and metadata schema version 1. Rustc results require an output directory tree plus metadata referencing raw stdout and stderr blobs so clients can replay compiler diagnostics byte-for-byte.
+`GET /v1/capabilities` advertises the action kinds and exact schema versions accepted by the server. Action-result keys use BLAKE3. The server accepts task, rustc, and cc action schema version 1, build-script action schema version 2, and metadata schema version 1 for every kind. Rustc, cc, and build-script results require an output directory tree plus metadata referencing raw stdout and stderr blobs so clients can replay diagnostics byte-for-byte.
 
 ## Operations
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,7 +1,9 @@
 #[cfg(test)]
 pub use mbx_cache_protocol::ActionPrediction as TaskActionPrediction;
 pub use mbx_cache_protocol::DigestAlgorithm as Algorithm;
-pub use mbx_cache_protocol::{ActionResult, Digest, Directory, RustcMetadata, TaskActionManifest};
+pub use mbx_cache_protocol::{
+    ActionResult, CcMetadata, Digest, Directory, RustcMetadata, TaskActionManifest,
+};
 use serde::Deserialize;
 use std::collections::{BTreeMap, HashSet};
 
@@ -137,6 +139,73 @@ pub struct RustcLinkerIdentity {
     pub sdk: Option<String>,
     #[serde(default)]
     pub deployment_target: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CcAction {
+    pub version: u8,
+    pub kind: String,
+    pub adapter_version: u8,
+    #[serde(default)]
+    pub assembly_input_model: Option<u8>,
+    pub compiler: CcCompiler,
+    pub arguments: Vec<String>,
+    pub environment: BTreeMap<String, Option<String>>,
+    pub inputs: Vec<CcInput>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CcCompiler {
+    pub assembler: String,
+    pub family: String,
+    pub target: String,
+    pub version_text: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CcInput {
+    pub digest: Digest,
+    pub path: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct BuildScriptAction {
+    pub version: u8,
+    pub kind: String,
+    pub binary_action: Digest,
+    pub cargo_environment: BTreeMap<String, Option<String>>,
+    pub environment: BTreeMap<String, Option<String>>,
+    pub inputs: BTreeMap<String, BuildScriptInput>,
+    pub out_dir: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+pub enum BuildScriptInput {
+    Missing,
+    File {
+        digest: Digest,
+    },
+    Directory {
+        digest: Digest,
+    },
+    Symlink {
+        target: String,
+        referent: Box<BuildScriptInput>,
+    },
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct BuildScriptMetadata {
+    pub version: u8,
+    pub kind: String,
+    pub stdout: Digest,
+    pub stderr: Digest,
 }
 
 fn valid_string(value: &str) -> bool {
@@ -275,6 +344,92 @@ impl RustcLinkerIdentity {
                 .as_deref()
                 .is_none_or(|value| !value.is_empty() && valid_string(value))
     }
+}
+
+impl CcAction {
+    pub fn validate(&self) -> bool {
+        let mut input_paths = HashSet::new();
+        self.version == 1
+            && self.kind == "cc"
+            && self.adapter_version > 0
+            && self.assembly_input_model.is_none_or(|version| version == 1)
+            && self.compiler.validate()
+            && valid_strings(&self.arguments)
+            && valid_optional_string_map(&self.environment)
+            && !self.inputs.is_empty()
+            && self
+                .inputs
+                .iter()
+                .all(|input| input.validate() && input_paths.insert(&input.path))
+    }
+}
+
+impl CcCompiler {
+    fn validate(&self) -> bool {
+        [
+            &self.assembler,
+            &self.family,
+            &self.target,
+            &self.version_text,
+        ]
+        .into_iter()
+        .all(|value| !value.is_empty() && valid_string(value))
+    }
+}
+
+impl CcInput {
+    fn validate(&self) -> bool {
+        // System headers are intentionally left as host paths, and include
+        // manifests use an adapter-owned prefix. These are key inputs rather
+        // than paths the server reads, so only their serialized integrity is
+        // relevant here.
+        !self.path.is_empty() && valid_string(&self.path) && self.digest.validate().is_ok()
+    }
+}
+
+impl BuildScriptAction {
+    pub fn validate(&self) -> bool {
+        self.version == 2
+            && self.kind == "build-script"
+            && self.binary_action.validate().is_ok()
+            && valid_optional_string_map(&self.cargo_environment)
+            && valid_optional_string_map(&self.environment)
+            && self
+                .inputs
+                .iter()
+                .all(|(path, input)| valid_string(path) && !path.is_empty() && input.validate(0))
+            && self.out_dir.as_deref().is_none_or(valid_string)
+    }
+}
+
+impl BuildScriptInput {
+    fn validate(&self, depth: usize) -> bool {
+        if depth > 64 {
+            return false;
+        }
+        match self {
+            Self::Missing => true,
+            Self::File { digest } | Self::Directory { digest } => digest.validate().is_ok(),
+            Self::Symlink { target, referent } => {
+                valid_string(target) && referent.validate(depth + 1)
+            }
+        }
+    }
+}
+
+impl BuildScriptMetadata {
+    pub fn validate(&self) -> bool {
+        self.version == 1
+            && self.kind == "build-script"
+            && self.stdout.validate().is_ok()
+            && self.stderr.validate().is_ok()
+    }
+}
+
+fn valid_optional_string_map(values: &BTreeMap<String, Option<String>>) -> bool {
+    values.iter().all(|(key, value)| {
+        !key.is_empty() && valid_string(key) && value.as_deref().is_none_or(valid_string)
+    })
 }
 
 fn valid_normalized_path(path: &str) -> bool {

--- a/src/server.rs
+++ b/src/server.rs
@@ -955,7 +955,7 @@ fn validate_action_result_shape(
         && (result.metadata.is_none() || result.output_root.is_none())
     {
         return Err(ApiError::unprocessable(
-            "rustc action results require metadata and an output root",
+            "compiler action results require metadata and an output root",
         ));
     }
     Ok(())

--- a/src/server.rs
+++ b/src/server.rs
@@ -151,6 +151,8 @@ async fn capabilities(State(state): State<AppState>) -> impl IntoResponse {
     capabilities.digest_algorithms = vec!["blake3".into(), "sha256".into()];
     capabilities.compressors = vec!["identity".into(), "zstd".into()];
     capabilities.action_kinds = BTreeMap::from([
+        ("build-script".into(), ActionKindCapability::new(2, 1)),
+        ("cc".into(), ActionKindCapability::new(1, 1)),
         ("rustc".into(), ActionKindCapability::new(1, 1)),
         ("task".into(), ActionKindCapability::new(1, 1)),
     ]);
@@ -939,6 +941,8 @@ async fn validate_tree(state: &AppState, namespace: &str, root: &Digest) -> Resu
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum ActionKind {
+    BuildScript,
+    Cc,
     Rustc,
     Task,
 }
@@ -947,7 +951,7 @@ fn validate_action_result_shape(
     result: &ActionResult,
     action_kind: ActionKind,
 ) -> Result<(), ApiError> {
-    if action_kind == ActionKind::Rustc
+    if action_kind != ActionKind::Task
         && (result.metadata.is_none() || result.output_root.is_none())
     {
         return Err(ApiError::unprocessable(
@@ -976,12 +980,49 @@ async fn validate_action_descriptor(
         .and_then(serde_json::Value::as_u64)
         .ok_or_else(|| ApiError::unprocessable("action descriptor version is required"))?;
     match kind.as_str() {
+        "build-script" => validate_build_script_action(value, version),
+        "cc" => validate_cc_action(value, version),
         "task" => validate_task_action(value, version),
         "rustc" => validate_rustc_action(value, version),
         _ => Err(ApiError::unprocessable(format!(
             "unsupported action kind {kind:?}"
         ))),
     }
+}
+
+fn validate_build_script_action(
+    value: serde_json::Value,
+    version: u64,
+) -> Result<ActionKind, ApiError> {
+    if version != 2 {
+        return Err(ApiError::unprocessable(format!(
+            "unsupported build-script action schema {version}"
+        )));
+    }
+    let action =
+        serde_json::from_value::<crate::model::BuildScriptAction>(value).map_err(|error| {
+            ApiError::unprocessable(format!("invalid build-script action: {error}"))
+        })?;
+    if !action.validate() {
+        return Err(ApiError::unprocessable(
+            "invalid build-script action values",
+        ));
+    }
+    Ok(ActionKind::BuildScript)
+}
+
+fn validate_cc_action(value: serde_json::Value, version: u64) -> Result<ActionKind, ApiError> {
+    if version != 1 {
+        return Err(ApiError::unprocessable(format!(
+            "unsupported cc action schema {version}"
+        )));
+    }
+    let action = serde_json::from_value::<crate::model::CcAction>(value)
+        .map_err(|error| ApiError::unprocessable(format!("invalid cc action: {error}")))?;
+    if !action.validate() {
+        return Err(ApiError::unprocessable("invalid cc action values"));
+    }
+    Ok(ActionKind::Cc)
 }
 
 fn validate_task_action(value: serde_json::Value, version: u64) -> Result<ActionKind, ApiError> {
@@ -1057,6 +1098,8 @@ async fn validate_client_metadata(
         .and_then(serde_json::Value::as_u64)
         .ok_or_else(|| ApiError::unprocessable("client metadata version is required"))?;
     let expected_kind = match action_kind {
+        ActionKind::BuildScript => "build-script",
+        ActionKind::Cc => "cc",
         ActionKind::Rustc => "rustc",
         ActionKind::Task => "task",
     };
@@ -1067,8 +1110,61 @@ async fn validate_client_metadata(
     }
     match action_kind {
         ActionKind::Task => validate_task_metadata(value, version),
+        ActionKind::BuildScript => {
+            validate_build_script_metadata(state, namespace, value, version).await
+        }
+        ActionKind::Cc => validate_cc_metadata(state, namespace, value, version).await,
         ActionKind::Rustc => validate_rustc_metadata(state, namespace, value, version).await,
     }
+}
+
+async fn validate_build_script_metadata(
+    state: &AppState,
+    namespace: &str,
+    value: serde_json::Value,
+    version: u64,
+) -> Result<(), ApiError> {
+    if version != 1 {
+        return Err(ApiError::unprocessable(format!(
+            "unsupported build-script metadata schema {version}"
+        )));
+    }
+    let metadata: crate::model::BuildScriptMetadata =
+        serde_json::from_value(value).map_err(|error| {
+            ApiError::unprocessable(format!("invalid build-script metadata: {error}"))
+        })?;
+    if !metadata.validate() {
+        return Err(ApiError::unprocessable(
+            "invalid build-script metadata values",
+        ));
+    }
+    require_output_blobs(
+        state,
+        namespace,
+        &metadata.stdout,
+        &metadata.stderr,
+        "build-script",
+    )
+    .await
+}
+
+async fn validate_cc_metadata(
+    state: &AppState,
+    namespace: &str,
+    value: serde_json::Value,
+    version: u64,
+) -> Result<(), ApiError> {
+    if version != 1 {
+        return Err(ApiError::unprocessable(format!(
+            "unsupported cc metadata schema {version}"
+        )));
+    }
+    let metadata: crate::model::CcMetadata = serde_json::from_value(value)
+        .map_err(|error| ApiError::unprocessable(format!("invalid cc metadata: {error}")))?;
+    if !metadata.validate() {
+        return Err(ApiError::unprocessable("invalid cc metadata values"));
+    }
+    require_output_blobs(state, namespace, &metadata.stdout, &metadata.stderr, "cc").await
 }
 
 fn validate_task_metadata(value: serde_json::Value, version: u64) -> Result<(), ApiError> {
@@ -1104,9 +1200,25 @@ async fn validate_rustc_metadata(
     if !metadata.validate() {
         return Err(ApiError::unprocessable("invalid rustc metadata values"));
     }
-    require_blob(state, namespace, &metadata.stdout, "rustc stdout blob").await?;
-    require_blob(state, namespace, &metadata.stderr, "rustc stderr blob").await?;
-    Ok(())
+    require_output_blobs(
+        state,
+        namespace,
+        &metadata.stdout,
+        &metadata.stderr,
+        "rustc",
+    )
+    .await
+}
+
+async fn require_output_blobs(
+    state: &AppState,
+    namespace: &str,
+    stdout: &Digest,
+    stderr: &Digest,
+    kind: &str,
+) -> Result<(), ApiError> {
+    require_blob(state, namespace, stdout, &format!("{kind} stdout blob")).await?;
+    require_blob(state, namespace, stderr, &format!("{kind} stderr blob")).await
 }
 
 fn validate_task_root(root: &str) -> Result<(), ApiError> {
@@ -1490,9 +1602,43 @@ mod tests {
         }))
     }
 
-    fn rustc_metadata(stdout: &Digest, stderr: &Digest, version: u8) -> Vec<u8> {
+    fn cc_action(input: &Digest, version: u8) -> Vec<u8> {
         canonical(serde_json::json!({
-            "kind":"rustc",
+            "adapter_version":1,
+            "arguments":["-c", "${workspace}/src/widget.c", "-o", "${target}/widget.o"],
+            "assembly_input_model":null,
+            "compiler":{
+                "assembler":"cc",
+                "family":"gnu",
+                "target":"x86_64-unknown-linux-gnu",
+                "version_text":"cc 15.2.0"
+            },
+            "environment":{},
+            "inputs":[
+                {"digest":input,"path":"${workspace}/src/widget.c"},
+                {"digest":input,"path":"/usr/include/stdio.h"},
+                {"digest":input,"path":"@include-manifest:${workspace}/src"}
+            ],
+            "kind":"cc",
+            "version":version
+        }))
+    }
+
+    fn build_script_action(binary_action: &Digest, version: u8) -> Vec<u8> {
+        canonical(serde_json::json!({
+            "binary_action":binary_action,
+            "cargo_environment":{"TARGET":"x86_64-unknown-linux-gnu"},
+            "environment":{},
+            "inputs":{"${workspace}/build.rs":{"kind":"missing"}},
+            "kind":"build-script",
+            "out_dir":null,
+            "version":version
+        }))
+    }
+
+    fn compiler_metadata(kind: &str, stdout: &Digest, stderr: &Digest, version: u8) -> Vec<u8> {
+        canonical(serde_json::json!({
+            "kind":kind,
             "stderr":stderr,
             "stdout":stdout,
             "version":version
@@ -2009,6 +2155,10 @@ mod tests {
                 .unwrap();
         assert_eq!(body["action_kinds"]["task"]["action_schema"], 1);
         assert_eq!(body["action_kinds"]["task"]["metadata_schema"], 1);
+        assert_eq!(body["action_kinds"]["build-script"]["action_schema"], 2);
+        assert_eq!(body["action_kinds"]["build-script"]["metadata_schema"], 1);
+        assert_eq!(body["action_kinds"]["cc"]["action_schema"], 1);
+        assert_eq!(body["action_kinds"]["cc"]["metadata_schema"], 1);
         assert_eq!(body["action_kinds"]["rustc"]["action_schema"], 1);
         assert_eq!(body["action_kinds"]["rustc"]["metadata_schema"], 1);
         assert_eq!(body["features"]["blob_packs"], true);
@@ -2048,6 +2198,56 @@ mod tests {
             StatusCode::CREATED
         );
         action
+    }
+
+    async fn publish_compiler_result(app: &Router, action: &[u8], kind: &str) -> StatusCode {
+        let action = upload_blob(app, action).await;
+        let stdout = upload_blob(app, b"").await;
+        let stderr = upload_blob(app, b"diagnostic\n").await;
+        let metadata = upload_blob(app, &compiler_metadata(kind, &stdout, &stderr, 1)).await;
+        let artifact = upload_blob(app, b"compiled artifact").await;
+        let output_root = upload_blob(app, &output_directory(&artifact)).await;
+        let result_uri = format!(
+            "/v1/action-results/{}/{}/{}",
+            action.algorithm, action.hash, action.size
+        );
+        let body = serde_json::to_vec(&ActionResult {
+            action,
+            metadata: Some(metadata),
+            output_root: Some(output_root),
+            version: 1,
+        })
+        .unwrap();
+        app.clone()
+            .oneshot(request("PUT", result_uri, Body::from(body)))
+            .await
+            .unwrap()
+            .status()
+    }
+
+    #[tokio::test]
+    async fn publishes_cc_results() {
+        let (app, _directory) = test_app().await;
+        let input = digest(b"int widget(void) { return 42; }\n");
+        assert_eq!(
+            publish_compiler_result(&app, &cc_action(&input, 1), "cc").await,
+            StatusCode::CREATED
+        );
+    }
+
+    #[tokio::test]
+    async fn publishes_build_script_results() {
+        let (app, _directory) = test_app().await;
+        let binary_action = digest(b"build script binary action");
+        assert_eq!(
+            publish_compiler_result(
+                &app,
+                &build_script_action(&binary_action, 2),
+                "build-script",
+            )
+            .await,
+            StatusCode::CREATED
+        );
     }
 
     /// A manifest is read back byte-for-byte as the canonical JSON its digest
@@ -2451,7 +2651,7 @@ mod tests {
         let action = upload_blob(&app, &rustc_action(&source, 1)).await;
         let stdout = upload_blob(&app, b"").await;
         let stderr = upload_blob(&app, b"warning: cached diagnostic\n").await;
-        let metadata = upload_blob(&app, &rustc_metadata(&stdout, &stderr, 1)).await;
+        let metadata = upload_blob(&app, &compiler_metadata("rustc", &stdout, &stderr, 1)).await;
         let artifact = upload_blob(&app, b"rlib artifact").await;
         let output_root = upload_blob(&app, &output_directory(&artifact)).await;
         let result_uri = format!(
@@ -2495,7 +2695,7 @@ mod tests {
         let action = upload_blob(&app, &canonical(action)).await;
         let stdout = upload_blob(&app, b"").await;
         let stderr = upload_blob(&app, b"linker diagnostic\n").await;
-        let metadata = upload_blob(&app, &rustc_metadata(&stdout, &stderr, 1)).await;
+        let metadata = upload_blob(&app, &compiler_metadata("rustc", &stdout, &stderr, 1)).await;
         let executable = upload_blob(&app, b"linked executable").await;
         let output_root = upload_blob(&app, &output_directory(&executable)).await;
         let result_uri = format!(
@@ -2552,7 +2752,11 @@ mod tests {
         let action = upload_blob(&app, &rustc_action(&source, 1)).await;
         let stdout = upload_blob(&app, b"").await;
         let missing_stderr = digest(b"missing diagnostic\n");
-        let metadata = upload_blob(&app, &rustc_metadata(&stdout, &missing_stderr, 1)).await;
+        let metadata = upload_blob(
+            &app,
+            &compiler_metadata("rustc", &stdout, &missing_stderr, 1),
+        )
+        .await;
         let artifact = upload_blob(&app, b"rlib artifact").await;
         let output_root = upload_blob(&app, &output_directory(&artifact)).await;
         let result_uri = format!(
@@ -2651,7 +2855,7 @@ mod tests {
         let stdout = upload_blob(&app, b"").await;
         let stderr = upload_blob(&app, b"warning\n").await;
         let mut metadata: serde_json::Value =
-            serde_json::from_slice(&rustc_metadata(&stdout, &stderr, 1)).unwrap();
+            serde_json::from_slice(&compiler_metadata("rustc", &stdout, &stderr, 1)).unwrap();
         metadata["unknown"] = true.into();
         let metadata = upload_blob(&app, &canonical(metadata)).await;
         let artifact = upload_blob(&app, b"rlib artifact").await;


### PR DESCRIPTION
## Summary

- advertise the `cc` v1 and `build-script` v2 action schemas
- validate their action descriptors and compiler output metadata
- require referenced diagnostic blobs and output trees before publishing results
- cover both action kinds with end-to-end server tests

This fixes the `422 unsupported action kind` errors seen while seeding the Azure-backed cache from the hk main workflow.

## Verification

- `cargo +1.97.1 fmt --check`
- `cargo +1.97.1 test`
- `cargo +1.97.1 clippy --all-targets --all-features -- -D warnings`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes expand action-result validation on the publish path; behavior mirrors existing rustc checks rather than altering auth or storage semantics.
> 
> **Overview**
> The cache server now accepts **`cc`** (action schema v1) and **`build-script`** (action schema v2) action descriptors instead of returning `422 unsupported action kind`, which unblocks seeding workflows that publish those action kinds.
> 
> **`/v1/capabilities`** advertises both kinds with their schema versions, and the README documents the expanded support alongside rustc. On **`PUT` action results**, the server deserializes and validates the new descriptor shapes in `model.rs` (including build-script’s nested input tree), checks matching client metadata, and applies the same **output tree + stdout/stderr blob** requirements previously limited to rustc—now generalized to all non-`task` compiler-like kinds via shared **`require_output_blobs`**. End-to-end tests cover successful publication for `cc` and `build-script`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fd84bb672e8e07cc34f10dd74d26e5f35bfd70b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for C/C++ compilation and build-script actions.
  - These action types are now advertised through the capabilities API.
  - Added support for publishing and validating C/C++ and build-script results.
  - Compiler and build-script results now include output trees and metadata linking to raw standard output and error data for diagnostic replay.

- **Documentation**
  - Updated API documentation with supported action and metadata schema versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->