### PR TITLE
fix: accept complete cache seed data

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -366,14 +366,10 @@ impl CcAction {
 
 impl CcCompiler {
     fn validate(&self) -> bool {
-        [
-            &self.assembler,
-            &self.family,
-            &self.target,
-            &self.version_text,
-        ]
-        .into_iter()
-        .all(|value| !value.is_empty() && valid_string(value))
+        valid_string(&self.assembler)
+            && [&self.family, &self.target, &self.version_text]
+                .into_iter()
+                .all(|value| !value.is_empty() && valid_string(value))
     }
 }
 
@@ -459,6 +455,18 @@ fn valid_normalized_path(path: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn cc_compilers_allow_an_empty_assembler_identity() {
+        let compiler = CcCompiler {
+            assembler: String::new(),
+            family: "apple-clang".into(),
+            target: "arm64-apple-darwin23.6.0".into(),
+            version_text: "Apple clang version 15.0.0".into(),
+        };
+
+        assert!(compiler.validate());
+    }
 
     #[test]
     fn validates_lowercase_hex_digests() {

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,7 +1,7 @@
 use axum::{
     Json, Router,
-    body::{Body, Bytes},
-    extract::{DefaultBodyLimit, Path, State},
+    body::{Body, Bytes, to_bytes},
+    extract::{Path, Request, State},
     http::{HeaderMap, StatusCode, header},
     response::{IntoResponse, Response},
     routing::{get, post},
@@ -82,8 +82,8 @@ pub fn router(state: AppState) -> Router {
     // kilobytes to fill that buffer. Axum's own 2 MB default bounds them --
     // `json_routes_keep_axums_default_body_limit` pins it -- and the largest
     // legitimate request, MAX_BATCH_ITEMS digests, is about 1.1 MB. Action
-    // manifests are the exception: a large build can legitimately carry more
-    // than 2 MB of predictions, so that route has its own explicit bound.
+    // manifests are the exception: their handler authenticates before reading
+    // a body under its own explicit bound.
     let blobs = Router::new()
         .route(
             "/v1/blobs/{algorithm}/{hash}/{size}",
@@ -107,18 +107,11 @@ pub fn router(state: AppState) -> Router {
         .layer(RequestBodyLimitLayer::new(pack_limit))
         .layer(RequestDecompressionLayer::new())
         .layer(RequestBodyLimitLayer::new(pack_limit));
-    let action_manifests = Router::new()
-        .route(
-            "/v1/action-manifests/{algorithm}/{hash}/{size}",
-            get(get_action_manifest).put(put_action_manifest),
-        )
-        .layer(DefaultBodyLimit::max(MAX_ACTION_MANIFEST_BYTES));
     Router::new()
         .route("/v1/status", get(status))
         .route("/v1/capabilities", get(capabilities))
         .merge(blobs)
         .merge(pack_uploads)
-        .merge(action_manifests)
         .route("/v1/blobs:missing", post(missing_blobs))
         .route("/v1/blobs:pack", post(pack_blobs))
         .route(
@@ -126,6 +119,10 @@ pub fn router(state: AppState) -> Router {
             get(get_action_result).put(put_action_result),
         )
         .route("/v1/action-results:batch", post(batch_action_results))
+        .route(
+            "/v1/action-manifests/{algorithm}/{hash}/{size}",
+            get(get_action_manifest).put(put_action_manifest),
+        )
         .route("/metrics", get(metrics))
         // Fastest: rustc artifacts still compress well below level 1's cost,
         // and a cache server's CPU is better spent serving than squeezing.
@@ -814,11 +811,19 @@ async fn get_action_manifest(
 
 async fn put_action_manifest(
     State(state): State<AppState>,
-    headers: HeaderMap,
     Path(parts): Path<(String, String, u64)>,
-    Json(manifest): Json<TaskActionManifest>,
+    request: Request,
 ) -> Result<Response, ApiError> {
-    let namespace = state.auth.authorize(&headers, Access::Write).await?;
+    let namespace = state
+        .auth
+        .authorize(request.headers(), Access::Write)
+        .await?;
+    let headers = request.headers().clone();
+    let body = to_bytes(request.into_body(), MAX_ACTION_MANIFEST_BYTES)
+        .await
+        .map_err(|_| ApiError::too_large("action manifest is too large"))?;
+    let manifest: TaskActionManifest = serde_json::from_slice(&body)
+        .map_err(|error| ApiError::bad_request(format!("invalid action manifest: {error}")))?;
     let key = parse_action_digest(parts)?;
     if !manifest.validate() || manifest.selector_digest() != key {
         return Err(ApiError::bad_request(

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,7 +1,7 @@
 use axum::{
     Json, Router,
     body::{Body, Bytes},
-    extract::{Path, State},
+    extract::{DefaultBodyLimit, Path, State},
     http::{HeaderMap, StatusCode, header},
     response::{IntoResponse, Response},
     routing::{get, post},
@@ -45,6 +45,7 @@ use crate::{
 
 const BLOB_PACK_HEADER_BYTES: usize = mbx_cache_protocol::BLOB_PACK_HEADER_BYTES as usize;
 const MAX_PACK_STORAGE_READS: usize = 16;
+const MAX_ACTION_MANIFEST_BYTES: usize = 16 * 1024 * 1024;
 
 #[derive(Clone)]
 pub struct AppState {
@@ -80,7 +81,9 @@ pub fn router(state: AppState) -> Router {
     // there is no reason to let an unauthenticated caller spend a few
     // kilobytes to fill that buffer. Axum's own 2 MB default bounds them --
     // `json_routes_keep_axums_default_body_limit` pins it -- and the largest
-    // legitimate request, MAX_BATCH_ITEMS digests, is about 1.1 MB.
+    // legitimate request, MAX_BATCH_ITEMS digests, is about 1.1 MB. Action
+    // manifests are the exception: a large build can legitimately carry more
+    // than 2 MB of predictions, so that route has its own explicit bound.
     let blobs = Router::new()
         .route(
             "/v1/blobs/{algorithm}/{hash}/{size}",
@@ -104,11 +107,18 @@ pub fn router(state: AppState) -> Router {
         .layer(RequestBodyLimitLayer::new(pack_limit))
         .layer(RequestDecompressionLayer::new())
         .layer(RequestBodyLimitLayer::new(pack_limit));
+    let action_manifests = Router::new()
+        .route(
+            "/v1/action-manifests/{algorithm}/{hash}/{size}",
+            get(get_action_manifest).put(put_action_manifest),
+        )
+        .layer(DefaultBodyLimit::max(MAX_ACTION_MANIFEST_BYTES));
     Router::new()
         .route("/v1/status", get(status))
         .route("/v1/capabilities", get(capabilities))
         .merge(blobs)
         .merge(pack_uploads)
+        .merge(action_manifests)
         .route("/v1/blobs:missing", post(missing_blobs))
         .route("/v1/blobs:pack", post(pack_blobs))
         .route(
@@ -116,10 +126,6 @@ pub fn router(state: AppState) -> Router {
             get(get_action_result).put(put_action_result),
         )
         .route("/v1/action-results:batch", post(batch_action_results))
-        .route(
-            "/v1/action-manifests/{algorithm}/{hash}/{size}",
-            get(get_action_manifest).put(put_action_manifest),
-        )
         .route("/metrics", get(metrics))
         // Fastest: rustc artifacts still compress well below level 1's cost,
         // and a cache server's CPU is better spent serving than squeezing.
@@ -2248,6 +2254,38 @@ mod tests {
             .await,
             StatusCode::CREATED
         );
+    }
+
+    #[tokio::test]
+    async fn accepts_action_manifests_larger_than_axums_default_limit() {
+        let (app, _directory) = test_app().await;
+        let manifest = TaskActionManifest {
+            predictions: (0..10_000)
+                .map(|index| crate::model::TaskActionPrediction {
+                    action: digest(format!("action-{index}").as_bytes()),
+                    adapter: "rustc".into(),
+                    invocation: digest(format!("invocation-{index}").as_bytes()),
+                    payload: "{}".into(),
+                })
+                .collect(),
+            task: "b".repeat(64),
+            version: 1,
+        };
+        let key = manifest.selector_digest();
+        let body = serde_json::to_vec(&manifest).unwrap();
+        assert!(body.len() > 2 * 1024 * 1024);
+        assert!(body.len() < MAX_ACTION_MANIFEST_BYTES);
+        let uri = format!(
+            "/v1/action-manifests/{}/{}/{}",
+            key.algorithm, key.hash, key.size
+        );
+
+        let response = app
+            .oneshot(request("PUT", uri, Body::from(body)))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::CREATED);
     }
 
     /// A manifest is read back byte-for-byte as the canonical JSON its digest


### PR DESCRIPTION
## Summary

- accept the empty assembler identity emitted for valid macOS cc actions
- give action manifests a bounded 16 MiB request limit instead of Axum's 2 MiB JSON default
- add regressions for both production failures observed while reseeding the hk cache

## Validation

- `rustup run 1.98.0 cargo test`
- `cargo fmt --check`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted validation and one-handler request flow change with bounded reads and existing manifest checks; no auth or blob-storage behavior changes elsewhere.
> 
> **Overview**
> Fixes two issues that blocked **reseeding the remote build cache**: macOS cc actions with a blank assembler field were rejected, and large **action manifest** uploads failed under Axum’s default **2 MiB** body limit.
> 
> **Cc compiler validation** no longer requires a non-empty `assembler`; it still checks string safety on `assembler` and keeps **family**, **target**, and **version_text** required and non-empty.
> 
> **PUT `/v1/action-manifests`** now **authenticates first**, then reads the body with an explicit **16 MiB** cap (`MAX_ACTION_MANIFEST_BYTES`) before JSON parsing, instead of using the `Json` extractor. Other JSON routes stay on the **2 MiB** default.
> 
> Regressions cover empty-assembler cc metadata and manifests **>2 MiB** but **<16 MiB**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71eb9ccaedb4ed3549611fe293d62ad39ef51b1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Compiler validation now succeeds when the assembler identity is left blank, while other required compiler details continue to be validated.
  - Action manifests larger than 2 MB can now be uploaded successfully, with support for payloads up to 16 MB.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->