### PR TITLE
fix: update yanked chacha20 dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -767,9 +767,9 @@ checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",


### PR DESCRIPTION
## Summary

- update `chacha20` from yanked version 0.10.1 to 0.10.2
- restore the scheduled `cargo deny check advisories` job

Fixes the failure in https://github.com/jdx/mr-boxington-cache/actions/runs/33729565521.

## Validation

- `cargo +1.95.0 test --locked --all-features` (73 passed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Patch-level lockfile bump for a yanked transitive crate; no source or behavior changes.
> 
> **Overview**
> Replaces the **yanked** `chacha20` **0.10.1** entry in `Cargo.lock` with **0.10.2** (updated checksum). This is a lockfile-only dependency refresh—`chacha20` is pulled in transitively via `rand` 0.10.x—so CI/advisory checks can resolve crates again without touching application code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 467dfc5ea7ad94688294aabd6f531f59c1ae6616. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->