### PR TITLE
perf: skip blob pack size preflight

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -546,40 +546,14 @@ async fn pack_blobs(
     let mut pack_payload_bytes = 0_u64;
     let store = state.blobs.clone();
     let metrics = state.metrics.clone();
-    let reads = stream::iter(visible.into_iter().map(|digest| {
-        let store = store.clone();
-        async move {
-            let size = match store.size(&digest).await {
-                Ok(Some(size)) => size,
-                Ok(None) => {
-                    return Err(ApiError::internal(io::Error::new(
-                        io::ErrorKind::NotFound,
-                        "visible blob is missing from storage",
-                    )));
-                }
-                Err(error) => {
-                    return Err(ApiError::internal(error));
-                }
-            };
-            if size != digest.size {
-                return Err(ApiError::internal(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    "stored blob size does not match its digest",
-                )));
-            }
-            Ok::<_, ApiError>((pack_blob_header(&digest)?, digest))
-        }
-    }));
-    let mut reads = reads.buffered(MAX_PACK_STORAGE_READS);
     let mut entries = Vec::new();
-    while let Some(entry) = reads.next().await {
-        let (header, digest) = match entry {
-            Ok(entry) => entry,
-            Err(error) => {
-                pack_guard.error();
-                return Err(error);
-            }
-        };
+    for digest in visible {
+        // The metadata index returned the exact requested digest, including
+        // its declared size. The streaming GET below reports and validates
+        // the stored object's real size before yielding its bytes, so a HEAD
+        // here would make every Azure blob pay for the same check twice and
+        // delay the first response byte until every HEAD completed.
+        let header = pack_blob_header(&digest)?;
         pack_payload_bytes = pack_payload_bytes
             .checked_add(digest.size)
             .ok_or_else(|| ApiError::too_large("blob pack is too large"))?;
@@ -589,7 +563,6 @@ async fn pack_blobs(
             .ok_or_else(|| ApiError::too_large("blob pack is too large"))?;
         entries.push((header, digest));
     }
-    drop(reads);
     let pack_blobs = entries.len();
     let stream_metrics = metrics.clone();
     let response_stream = async_stream::try_stream! {
@@ -1979,7 +1952,8 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(response.status(), StatusCode::OK);
+        assert!(response.into_body().collect().await.is_err());
     }
 
     #[tokio::test]
@@ -1999,7 +1973,8 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(response.status(), StatusCode::OK);
+        assert!(response.into_body().collect().await.is_err());
     }
 
     #[tokio::test]

--- a/src/storage/azure.rs
+++ b/src/storage/azure.rs
@@ -78,14 +78,6 @@ impl AzureStore {
 
 #[async_trait]
 impl BlobStore for AzureStore {
-    async fn size(&self, digest: &Digest) -> anyhow::Result<Option<u64>> {
-        match self.store.head(&self.key(digest)).await {
-            Ok(metadata) => Ok(Some(metadata.size)),
-            Err(Error::NotFound { .. }) => Ok(None),
-            Err(error) => Err(error.into()),
-        }
-    }
-
     async fn get(&self, digest: &Digest) -> anyhow::Result<Option<Blob>> {
         let result = match self.store.get(&self.key(digest)).await {
             Ok(result) => result,
@@ -211,23 +203,15 @@ mod tests {
             size: 10,
         };
 
-        assert_eq!(store.size(&digest).await.unwrap(), None);
+        assert!(store.get(&digest).await.unwrap().is_none());
         assert_eq!(
             store.put(&digest, source.path()).await.unwrap(),
             PutOutcome::Created
         );
-        assert_eq!(store.size(&digest).await.unwrap(), Some(10));
+        let blob = store.get(&digest).await.unwrap().unwrap();
+        assert_eq!(blob.size, 10);
         assert_eq!(
-            store
-                .get(&digest)
-                .await
-                .unwrap()
-                .unwrap()
-                .stream
-                .try_collect::<Vec<_>>()
-                .await
-                .unwrap()
-                .concat(),
+            blob.stream.try_collect::<Vec<_>>().await.unwrap().concat(),
             b"azure blob"[..]
         );
 
@@ -236,7 +220,7 @@ mod tests {
             store.put(&digest, source.path()).await.unwrap(),
             PutOutcome::AlreadyExists
         );
-        assert_eq!(store.size(&digest).await.unwrap(), Some(10));
+        assert_eq!(store.get(&digest).await.unwrap().unwrap().size, 10);
 
         tokio::fs::write(source.path(), b"").await.unwrap();
         let empty_digest = Digest {
@@ -248,7 +232,7 @@ mod tests {
             store.put(&empty_digest, source.path()).await.unwrap(),
             PutOutcome::Created
         );
-        assert_eq!(store.size(&empty_digest).await.unwrap(), Some(0));
+        assert_eq!(store.get(&empty_digest).await.unwrap().unwrap().size, 0);
         assert_eq!(
             store.put(&empty_digest, source.path()).await.unwrap(),
             PutOutcome::AlreadyExists

--- a/src/storage/filesystem.rs
+++ b/src/storage/filesystem.rs
@@ -37,14 +37,6 @@ impl FilesystemStore {
 
 #[async_trait]
 impl BlobStore for FilesystemStore {
-    async fn size(&self, digest: &Digest) -> anyhow::Result<Option<u64>> {
-        match tokio::fs::metadata(self.path(digest)?).await {
-            Ok(metadata) => Ok(Some(metadata.len())),
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
-            Err(error) => Err(error.into()),
-        }
-    }
-
     async fn get(&self, digest: &Digest) -> anyhow::Result<Option<Blob>> {
         let file = match tokio::fs::File::open(self.path(digest)?).await {
             Ok(file) => file,

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -31,7 +31,6 @@ pub enum PutOutcome {
 
 #[async_trait]
 pub trait BlobStore: Send + Sync {
-    async fn size(&self, digest: &Digest) -> anyhow::Result<Option<u64>>;
     async fn get(&self, digest: &Digest) -> anyhow::Result<Option<Blob>>;
     async fn put(&self, digest: &Digest, source: &Path) -> anyhow::Result<PutOutcome>;
 }

--- a/src/storage/s3.rs
+++ b/src/storage/s3.rs
@@ -42,33 +42,6 @@ impl S3Store {
 
 #[async_trait]
 impl BlobStore for S3Store {
-    async fn size(&self, digest: &Digest) -> anyhow::Result<Option<u64>> {
-        let output = match self
-            .client
-            .head_object()
-            .bucket(&self.bucket)
-            .key(self.key(digest))
-            .send()
-            .await
-        {
-            Ok(output) => output,
-            Err(error)
-                if error.as_service_error().is_some_and(|e| e.is_not_found())
-                    || error
-                        .raw_response()
-                        .is_some_and(|response| response.status().as_u16() == 404) =>
-            {
-                return Ok(None);
-            }
-            Err(error) => return Err(error.into()),
-        };
-        output
-            .content_length()
-            .and_then(|size| u64::try_from(size).ok())
-            .map(Some)
-            .ok_or_else(|| anyhow::anyhow!("S3 object response is missing content length"))
-    }
-
     async fn get(&self, digest: &Digest) -> anyhow::Result<Option<Blob>> {
         let output = match self
             .client


### PR DESCRIPTION
## Summary

- build blob-pack entries from the namespace-visible digests already returned by metadata
- remove the redundant object-store `size` operation and its Azure HEAD request
- continue validating every object's actual size from the streaming GET before yielding its payload
- update corrupt-object tests for streaming failures after the response begins

## Motivation

Blob packs previously performed one object-store size lookup per visible blob, waited for every lookup to finish, and then performed a GET for every blob. Azure implements the size lookup as a separate HEAD request, while the GET result already carries and validates the same size. This removes up to one Azure operation per packed blob and lets the response begin without a complete HEAD preflight.

## Validation

- `cargo +1.95.0 test`
- `cargo +1.95.0 clippy --all-features --all-targets -- -D warnings`
- `cargo +1.95.0 fmt --check`

## AI disclosure

This change was implemented with AI assistance.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes blob-pack error timing (streaming vs pre-response) and removes a storage API used only for pack preflight; integrity checks remain on the GET path but clients must handle mid-stream failures.
> 
> **Overview**
> **Blob pack responses start sooner** by dropping a per-blob object-store size check before streaming. Pack frame headers are built from digests already returned by metadata visibility; each blob is still opened with a concurrent `get`, and stored size is checked against the digest before bytes are yielded.
> 
> **`BlobStore::size` is removed** from the trait and from Azure, filesystem, and S3 backends (including Azure’s extra HEAD). Storage tests now assert presence and size via `get` only.
> 
> **Corrupt on-disk objects** in a pack no longer fail the HTTP handler up front with `500`; the response is `200` with headers set, and the body stream errors when the mismatch is detected during the GET/stream phase. Tests were updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 812de27297b541d81ccea512b488bef44d559c62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Blob-pack downloads now begin streaming sooner instead of waiting for all storage sizes to be checked.
  * Invalid or incomplete stored blobs are detected while the response is streaming, providing clearer download failure behavior.
  * Short and oversized stored objects are handled consistently during downloads.
* **Performance**
  * Reduced preliminary storage checks for blob-pack requests, improving time to the first response data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->